### PR TITLE
feat(tensor): add `is_autodiff` and `is_tracked` state inspection

### DIFF
--- a/burn-book/src/building-blocks/autodiff.md
+++ b/burn-book/src/building-blocks/autodiff.md
@@ -21,8 +21,19 @@ field on every parameter. Passing that container to `grad` or `grad_remove` make
 between the backward pass and gradient access explicit. `grad_remove` can also enable in-place
 optimizations when a gradient is consumed only once.
 
-Note that some functions will always be available even if the tensor is not on an autodiff-enabled
-device. In such cases, those functions will do nothing.
+Autodiff association, graph participation, and gradient retention are related but independent
+properties:
+
+| Property               | Accessor                                   | Related APIs                                                                             |
+| ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Autodiff association   | `tensor.is_autodiff()`                     | `autodiff()` / `without_autodiff()`                                                      |
+| Graph participation    | `tensor.is_tracked()`                      | `detach()` / operations with tracked inputs                                              |
+| Gradient retention     | `tensor.is_require_grad()`                 | `require_grad()` / `set_require_grad(...)`                                               |
+| Checkpointing strategy | `tensor.gradient_checkpointing_strategy()` | `autodiff().with_gradient_checkpointing_strategy(...)`                                   |
+
+`require_grad()` only controls whether a tensor's gradient is retained; it does not enable autodiff.
+On a tensor without autodiff, it is a no-op. `detach()` keeps the autodiff association but starts a
+new graph lineage, while `without_autodiff()` removes the association entirely.
 
 | Burn API                                | PyTorch Equivalent           |
 | --------------------------------------- | ---------------------------- |
@@ -57,6 +68,9 @@ With Burn, tensors shouldn't be on an autodiff device for inference, and you can
 `without_autodiff()` to obtain a tensor without autodiff, which is useful for validation. The
 historical `inner()` method is equivalent.
 
+When an operation combines a tensor with autodiff and a tensor without it, the operation uses
+autodiff and treats the latter tensor as a constant. The original tensor remains unchanged.
+
 ```rust, ignore
 fn example_validation(tensor: Tensor<2>) {
     debug_assert!(tensor.device().is_autodiff());
@@ -74,8 +88,8 @@ fn example_inference(tensor: Tensor<2>) {
 ## Gradients with Optimizers
 
 We've seen how gradients can be used with tensors, but the process is a bit different when working
-with optimizers from `burn-optim`. To work with the `Module` trait, a translation step is required to
-link tensor parameters with their gradients. This step is necessary to easily support gradient
+with optimizers from `burn-optim`. To work with the `Module` trait, a translation step is required
+to link tensor parameters with their gradients. This step is necessary to easily support gradient
 accumulation and training on multiple devices, where each module can be forked and run on different
 devices in parallel. The [Optimizer](./optimizer.md) section explains how those gradients update
 module parameters.

--- a/burn-book/src/building-blocks/backend.md
+++ b/burn-book/src/building-blocks/backend.md
@@ -84,25 +84,29 @@ let model = model.to_device(&gpu);
 
 ## Autodiff and Execution
 
-Automatic differentiation is a device capability. Calling `autodiff` returns a device that records
-the operations required for backpropagation:
+Automatic differentiation is configured on a device. Tensors created on an autodiff device inherit
+that context and can later change it independently. Calling `autodiff` returns such a device:
 
 ```rust, ignore
 let device = Device::wgpu(Default::default());
 let training_device = device.autodiff();
 
 assert!(training_device.is_autodiff());
-let inference_device = training_device.inner();
+let inference_device = training_device.without_autodiff();
 assert!(!inference_device.is_autodiff());
 ```
 
-`gradient_checkpointing` adds gradient checkpointing to an autodiff device. The following methods
-are also useful when coordinating execution:
+`autodiff()` and `without_autodiff()` are idempotent. The historical `inner()` method is equivalent
+to `without_autodiff()`. Chain `autodiff().gradient_checkpointing()` to enable autodiff with the
+balanced checkpointing strategy.
+
+The following methods are also useful when coordinating execution:
 
 - `seed(seed)` seeds random operations on the device.
 - `sync()` waits for queued work and reports an execution error if one occurred.
 - `flush()` submits queued work without waiting for completion.
-- `is_autodiff()` reports whether gradient tracking is enabled.
+- `is_autodiff()` reports whether autodiff is associated with the device.
+- `gradient_checkpointing_strategy()` returns the active strategy, or `None` without autodiff.
 - `supports_dtype(dtype)` reports whether the device supports a dtype.
 - `memory_cleanup()` asks the backend to release unused cached allocations.
 

--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -97,6 +97,26 @@ macro_rules! graph_replay_arms {
 }
 
 #[cfg(feature = "autodiff")]
+macro_rules! is_tracked_arms {
+    ($tensor:expr; $([$Backend:ident, $cfg:meta]),*) => {
+        match &$tensor.kind {
+            DispatchTensorKind::Autodiff(inner) => match &**inner {
+                $(
+                    #[cfg($cfg)]
+                    DispatchTensorKind::$Backend(tensor) => tensor.as_autodiff().is_tracked(),
+                )*
+                DispatchTensorKind::Autodiff(_) => {
+                    unreachable!("Autodiff should not wrap an autodiff tensor")
+                }
+                #[allow(unreachable_patterns)]
+                _ => false,
+            },
+            _ => false,
+        }
+    };
+}
+
+#[cfg(feature = "autodiff")]
 use alloc::boxed::Box;
 #[cfg(feature = "autodiff")]
 use burn_autodiff::grads::Gradients;
@@ -136,6 +156,15 @@ use crate::{DispatchDevice, DispatchTensor};
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct Dispatch;
+
+#[cfg(feature = "autodiff")]
+impl Dispatch {
+    /// Returns whether an autodiff tensor participates in a recorded graph.
+    #[doc(hidden)]
+    pub fn is_tracked(tensor: &DispatchTensor) -> bool {
+        backend_list!(is_tracked_arms, tensor)
+    }
+}
 
 impl BackendTypes for Dispatch {
     type Device = DispatchDevice;

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -33,7 +33,8 @@ use alloc::vec::Vec;
 ///
 /// [`Device`] provides a unified interface to interact with the underlying compute backend.
 ///
-/// Autodiff support is a property of the device rather than a separate type parameter.
+/// Autodiff support is configured on the device rather than through a separate type parameter.
+/// Tensors inherit that context when created and can later change it independently.
 #[cfg_attr(
     feature = "autodiff",
     doc = "Wrap a device with [`.autodiff()`](Device::autodiff) to enable automatic differentiation with the device."
@@ -78,8 +79,8 @@ use alloc::vec::Vec;
 /// ```rust,ignore
 /// let device = Device::default().autodiff();
 ///
-/// // Tensors created on this device will track gradients
-/// let x = Tensor::<1>::from_floats([1.0, 2.0, 3.0], &device);
+/// // Tensors created on this device can participate in an autodiff graph.
+/// let x = Tensor::<1>::from_floats([1.0, 2.0, 3.0], &device).require_grad();
 /// ```
 pub struct Device {
     blob: device_opaque::Opaque,
@@ -118,8 +119,9 @@ impl PartialEq for Device {
     /// Compares devices based on hardware identity.
     ///
     /// Returns `true` if both devices represent the same compute resource.
-    /// Note that this comparison ignores autodiff and checkpointing settings.
-    /// To check if two devices have identical capabilities, check [`Device::is_autodiff`].
+    /// Note that this comparison ignores autodiff and checkpointing settings. Inspect
+    /// [`Device::is_autodiff`] and `Device::gradient_checkpointing_strategy()` when execution
+    /// context also matters.
     fn eq(&self, other: &Self) -> bool {
         self.as_dispatch() == other.as_dispatch()
     }
@@ -542,41 +544,36 @@ impl Device {
 
     /// Enables autodiff on this device.
     ///
-    /// Autodiff is a property of the device: tensors created on the returned device
-    /// will participate in the autodiff graph.
+    /// Tensors created on the returned device inherit its autodiff context. A tensor can later
+    /// change that context independently with [`Tensor::autodiff`](crate::Tensor::autodiff) or
+    /// [`Tensor::without_autodiff`](crate::Tensor::without_autodiff).
     ///
-    /// Only first-order autodiff is supported. Calling this method on a device that
-    /// already has autodiff enabled will panic.
+    /// Calling this method on a device that already has autodiff enabled returns it unchanged,
+    /// preserving its gradient-checkpointing strategy. This operation is idempotent.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let device = Device::default().autodiff();
-    /// let x = Tensor::<1>::from_floats([1.0, 2.0, 3.0], &device);
-    /// // x.backward() is now available
+    /// let x = Tensor::<1>::from_floats([1.0, 2.0, 3.0], &device).require_grad();
+    /// let gradients = x.backward();
     /// ```
     ///
-    /// # Panics
-    ///
-    /// Panics if autodiff is already enabled on this device.
     #[cfg(feature = "autodiff")]
+    #[must_use]
     pub fn autodiff(self) -> Self {
         match self.into_dispatch() {
-            DispatchDevice::Autodiff(_) => unimplemented!("Only first-order autodiff is supported"),
+            device @ DispatchDevice::Autodiff(_) => Self::new(device),
             other => Self::new(DispatchDevice::autodiff(other)),
         }
     }
 
-    /// Returns an autodiff device's gradient checkpointing strategy.
-    ///
-    /// # Panics
-    ///
-    /// Panics if autodiff is not enabled on this device.
+    /// Returns this device's gradient-checkpointing strategy when autodiff is enabled.
     #[cfg(feature = "autodiff")]
-    pub fn gradient_checkpointing_strategy(&self) -> GradientCheckpointingStrategy {
+    pub fn gradient_checkpointing_strategy(&self) -> Option<GradientCheckpointingStrategy> {
         match self.as_dispatch() {
-            DispatchDevice::Autodiff(device) => device.gradient_checkpointing_strategy(),
-            _ => panic!("Autodiff is not enabled on this device"),
+            DispatchDevice::Autodiff(device) => Some(device.gradient_checkpointing_strategy()),
+            _ => None,
         }
     }
 
@@ -597,6 +594,7 @@ impl Device {
     ///
     /// Panics if autodiff is not enabled on this device.
     #[cfg(feature = "autodiff")]
+    #[must_use]
     pub fn gradient_checkpointing(self) -> Self {
         match self.into_dispatch() {
             DispatchDevice::Autodiff(device) => {
@@ -605,28 +603,41 @@ impl Device {
                     GradientCheckpointingStrategy::Balanced,
                 ))
             }
-            _ => panic!("Autodiff is not enabled on this device"),
+            _ => panic!(
+                "Device::gradient_checkpointing requires autodiff; call Device::autodiff first"
+            ),
         }
     }
 
-    /// Returns the underlying device, removing the autodiff capability if present.
+    /// Returns this device without its autodiff association.
     ///
-    /// If autodiff is not enabled, this method returns the device as-is.
+    /// If autodiff is not enabled, the device is returned unchanged. This operation is idempotent.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let device = Device::default().autodiff();
-    /// let inner_device = device.inner();
+    /// let inference_device = device.without_autodiff();
     ///
-    /// assert!(!inner_device.is_autodiff());
+    /// assert!(!inference_device.is_autodiff());
     /// ```
-    pub fn inner(self) -> Self {
+    #[must_use]
+    pub fn without_autodiff(self) -> Self {
         if self.is_autodiff() {
             Self::new(self.into_dispatch().inner())
         } else {
             self
         }
+    }
+
+    /// Returns this device without its autodiff association.
+    ///
+    /// This is equivalent to [`without_autodiff`](Self::without_autodiff). `inner` reflects the
+    /// historical backend-decorator model, while `without_autodiff` describes the device's runtime
+    /// property directly.
+    #[must_use]
+    pub fn inner(self) -> Self {
+        self.without_autodiff()
     }
 
     /// Synchronize the device, waiting for all pending operations to complete.
@@ -1243,14 +1254,27 @@ pub struct Devices(Vec<Device>);
 impl Devices {
     /// Enables autodiff across all contained devices.
     ///
-    /// Only first-order autodiff is supported. Calling this method on a device that
-    /// already has autodiff enabled will panic.
+    /// Devices that already have autodiff enabled are left unchanged, preserving their
+    /// gradient-checkpointing strategy.
     ///
     /// See [`Device::autodiff`].
     #[cfg(feature = "autodiff")]
+    #[must_use]
     pub fn autodiff(mut self) -> Self {
         for device in &mut self.0 {
             *device = core::mem::take(device).autodiff();
+        }
+
+        self
+    }
+
+    /// Removes the autodiff association from every contained device.
+    ///
+    /// See [`Device::without_autodiff`].
+    #[must_use]
+    pub fn without_autodiff(mut self) -> Self {
+        for device in &mut self.0 {
+            *device = core::mem::take(device).without_autodiff();
         }
 
         self
@@ -1357,6 +1381,8 @@ mod autodiff_move_tests {
         let t = Tensor::<2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
         let moved = t.to_device(&ad_device);
 
+        assert!(!moved.is_autodiff());
+        assert!(!moved.is_tracked());
         assert_eq!(
             moved.try_into_vec_as::<f32>().unwrap(),
             vec![1.0, 2.0, 3.0, 4.0]

--- a/crates/burn-tensor/src/tensor/api/autodiff.rs
+++ b/crates/burn-tensor/src/tensor/api/autodiff.rs
@@ -49,29 +49,56 @@ impl Gradients {
 
 #[cfg(feature = "autodiff")]
 impl<const D: usize> Tensor<D> {
-    /// Backward pass of the tensor.
+    /// Computes gradients by backpropagating from this tensor.
+    ///
+    /// The tensor must participate in an autodiff graph. Backward consumes the shared graph tape,
+    /// even though this method borrows the tensor, so calling it again through this tensor or one
+    /// of its clones may panic.
+    ///
+    /// # Panics
+    ///
+    /// Panics if autodiff is disabled, the tensor doesn't participate in a recorded graph, or the
+    /// graph tape has already been consumed.
     pub fn backward(&self) -> Gradients {
         backward_impl(&self.primitive)
     }
 
-    /// Get the gradients of a tensor if it exist.
+    /// Returns this tensor's retained gradient, if present.
     ///
-    /// Returns a new reference to the same tensor. Therefore the same grad tensor can
-    /// be accessed multiple times. If you only need to get the gradients one time,
-    /// consider using [grad_remove](Tensor::grad_remove) for better performance.
+    /// The returned gradient doesn't have an autodiff association. This returns `None` when the
+    /// tensor is outside autodiff, doesn't retain gradients, or isn't present in `grads`.
+    /// Repeated calls return handles to the same gradient. If the gradient is only needed once,
+    /// prefer [`grad_remove`](Tensor::grad_remove), which can enable in-place optimizations.
     pub fn grad(&self, grads: &Gradients) -> Option<Tensor<D>> {
         grad_impl(&self.primitive, grads).map(Tensor::new)
     }
 
-    /// Remove the grad tensor from the [grads](AutodiffBackend::Gradients) struct returning the result.
+    /// Removes and returns this tensor's retained gradient, if present.
+    ///
+    /// The returned gradient doesn't have an autodiff association. This returns `None` when the
+    /// tensor is outside autodiff, doesn't retain gradients, or isn't present in `grads`.
     pub fn grad_remove(&self, grads: &mut Gradients) -> Option<Tensor<D>> {
         grad_remove_impl(&self.primitive, grads).map(Tensor::new)
     }
 
-    /// Replace the grad tensor from the [grads](AutodiffBackend::Gradients) struct with the provided
-    /// gradient.
+    /// Replaces this tensor's entry in `grads` with `grad`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this tensor isn't associated with autodiff, if `grad` has an autodiff association,
+    /// or if the tensors use incompatible backends.
     pub fn grad_replace(&self, grads: &mut Gradients, grad: Tensor<D>) {
         grad_replace_impl(&self.primitive, grads, grad.primitive)
+    }
+
+    /// Returns whether this tensor participates in a recorded autodiff graph.
+    ///
+    /// A tensor can have autodiff enabled without being tracked, such as a constant that doesn't
+    /// require gradients. [`is_autodiff`](Tensor::is_autodiff) reports whether autodiff is enabled
+    /// for the tensor, while [`is_require_grad`](Tensor::is_require_grad) reports whether its
+    /// gradient is retained after backward.
+    pub fn is_tracked(&self) -> bool {
+        is_tracked_impl(&self.primitive)
     }
 }
 
@@ -84,12 +111,20 @@ fn backward_impl(p: &BridgeTensor) -> Gradients {
 fn grad_impl(p: &BridgeTensor, grads: &Gradients) -> Option<BridgeTensor> {
     // A non-float tensor — a packed base included — records no tape, so there
     // is no gradient to look up.
-    Dispatch::grad(p.try_as_float()?, grads.as_inner()).map(BridgeTensor::float)
+    let tensor = p.try_as_float()?;
+    if tensor.autodiff == DispatchAutodiffContext::Disabled {
+        return None;
+    }
+    Dispatch::grad(tensor, grads.as_inner()).map(BridgeTensor::float)
 }
 
 #[cfg(feature = "autodiff")]
 fn grad_remove_impl(p: &BridgeTensor, grads: &mut Gradients) -> Option<BridgeTensor> {
-    Dispatch::grad_remove(p.try_as_float()?, grads.as_inner_mut()).map(BridgeTensor::float)
+    let tensor = p.try_as_float()?;
+    if tensor.autodiff == DispatchAutodiffContext::Disabled {
+        return None;
+    }
+    Dispatch::grad_remove(tensor, grads.as_inner_mut()).map(BridgeTensor::float)
 }
 
 #[cfg(feature = "autodiff")]
@@ -97,7 +132,21 @@ fn grad_replace_impl(p: &BridgeTensor, grads: &mut Gradients, grad: BridgeTensor
     Dispatch::grad_replace(p.as_float(), grads.as_inner_mut(), grad.into_float())
 }
 
+#[cfg(feature = "autodiff")]
+fn is_tracked_impl(p: &BridgeTensor) -> bool {
+    p.try_as_float().is_some_and(Dispatch::is_tracked)
+}
+
 impl<const D: usize, K: Autodiff> Tensor<D, K> {
+    /// Returns whether autodiff is enabled for this tensor.
+    ///
+    /// This doesn't indicate whether the tensor participates in a recorded graph or retains its
+    /// gradient. Inspect those properties with [`is_tracked`](Tensor::is_tracked) and
+    /// [`is_require_grad`](Tensor::is_require_grad), respectively.
+    pub fn is_autodiff(&self) -> bool {
+        self.device().is_autodiff()
+    }
+
     /// Returns this tensor without its autodiff association.
     ///
     /// If the tensor uses autodiff, this moves it to the inner backend and drops any graph
@@ -107,6 +156,7 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
     /// This is equivalent to [`without_autodiff`](Tensor::without_autodiff). `inner` reflects the
     /// underlying backend-decorator model, while `without_autodiff` describes the operation in
     /// terms of the high-level tensor API.
+    #[must_use]
     pub fn inner(self) -> Tensor<D, K> {
         self.without_autodiff()
     }
@@ -121,8 +171,9 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
     /// its autodiff association, the returned tensor pays no autodiff dispatch for subsequent
     /// operations involving only tensors without autodiff. When combined with a tensor that still
     /// uses autodiff, it is treated as a constant for that operation.
+    #[must_use]
     pub fn without_autodiff(self) -> Self {
-        if self.device().is_autodiff() {
+        if self.is_autodiff() {
             Tensor::new(K::inner(self.primitive))
         } else {
             self
@@ -138,8 +189,9 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
     /// Enabling autodiff does not make a floating-point tensor require gradients. Use
     /// [`require_grad`](Tensor::require_grad) when its gradient should be retained during the
     /// backward pass.
+    #[must_use]
     pub fn autodiff(self) -> Self {
-        if self.device().is_autodiff() {
+        if self.is_autodiff() {
             self
         } else {
             Self::new(K::from_inner(self.primitive))
@@ -159,30 +211,42 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
     /// Enabling autodiff does not make a floating-point tensor require gradients. Use
     /// [`require_grad`](Tensor::require_grad) when its gradient should be retained during the
     /// backward pass.
+    #[must_use]
     pub fn from_inner(inner: Tensor<D, K>) -> Self {
         inner.autodiff()
+    }
+
+    /// Returns this tensor's gradient-checkpointing strategy when autodiff is enabled.
+    #[cfg(feature = "autodiff")]
+    pub fn gradient_checkpointing_strategy(&self) -> Option<GradientCheckpointingStrategy> {
+        match self.primitive.as_parts().1.autodiff {
+            DispatchAutodiffContext::Disabled => None,
+            DispatchAutodiffContext::Enabled(strategy) => Some(strategy),
+        }
     }
 
     /// Sets the autodiff checkpointing strategy carried by this tensor.
     ///
     /// The strategy is normally derived from the device the tensor was created on (see
     /// [`Device::gradient_checkpointing`](crate::Device::gradient_checkpointing)); this
-    /// method overrides it for a single tensor. A tensor carrying a strategy is treated
-    /// as tracked by autodiff, so this also marks an inner-backend tensor for tracking.
+    /// method overrides it for a single tensor. Enable autodiff first with
+    /// [`autodiff`](Tensor::autodiff) when needed.
     ///
     /// # Panics
     ///
-    /// Operations combining tensors that carry different strategies panic; make sure all
-    /// operands share the same one.
+    /// Panics if autodiff isn't enabled. Operations combining tensors that carry different
+    /// strategies also panic; make sure all operands share the same one.
     #[cfg(feature = "autodiff")]
+    #[must_use]
     pub fn with_gradient_checkpointing_strategy(
         self,
         strategy: GradientCheckpointingStrategy,
     ) -> Self {
-        let primitive = match self.primitive.as_parts().1.autodiff {
-            DispatchAutodiffContext::Disabled => K::from_inner(self.primitive),
-            DispatchAutodiffContext::Enabled(_) => self.primitive,
-        };
+        assert!(
+            self.is_autodiff(),
+            "Tensor::with_gradient_checkpointing_strategy requires autodiff; call Tensor::autodiff first"
+        );
+        let primitive = self.primitive;
         let (kind, mut tensor) = primitive.into_parts();
         tensor.autodiff = DispatchAutodiffContext::Enabled(strategy);
         Self::new(match kind {

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1594,7 +1594,21 @@ where
         K::device(&self.primitive)
     }
 
-    /// Move the tensor to the given device.
+    /// Moves the tensor to the target device's compute resource.
+    ///
+    /// Autodiff is tensor context as well as device metadata, so the returned tensor isn't
+    /// guaranteed to adopt the target device's autodiff setting. In particular, moving a
+    /// floating-point tensor without autodiff to an autodiff device keeps the tensor outside
+    /// autodiff. Inspect that state with [`is_autodiff`](Tensor::is_autodiff), and change it
+    /// explicitly with [`autodiff`](Tensor::autodiff) or
+    /// [`without_autodiff`](Tensor::without_autodiff).
+    ///
+    /// # Panics
+    ///
+    /// Panics when the backend doesn't support the requested transfer. Autodiff tensors currently
+    /// can't be moved between different backend implementations; remove their autodiff association
+    /// before such a transfer and enable it again afterwards.
+    #[must_use]
     pub fn to_device(self, device: &Device) -> Self {
         Self::new(K::to_device(self.primitive, device))
     }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -316,29 +316,48 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
 
     /// Detach the current tensor from the autodiff graph.
     ///
-    /// This function does nothing when autodiff is not enabled.
-    /// This can be used in batchers or elsewhere to ensure that previous operations are not
-    /// considered in the autodiff graph.
+    /// The returned tensor keeps its autodiff association but starts a new graph lineage, so
+    /// previous operations aren't considered during backward. A leaf tensor also preserves its
+    /// current `require_grad` setting. This function does nothing when autodiff isn't enabled.
+    #[must_use]
     pub fn detach(self) -> Self {
         Self::new(detach_impl(self.primitive))
     }
 
     /// Mark the tensor to keep gradients during the backward pass.
     ///
-    /// This function does nothing when autodiff is not enabled.
+    /// This function does nothing when autodiff isn't enabled or when the tensor is quantized.
+    /// Enabling gradient retention doesn't enable autodiff; use [`autodiff`](Tensor::autodiff)
+    /// first when needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called on a non-leaf tensor. Use [`detach`](Tensor::detach) first to start a new
+    /// graph lineage.
+    #[must_use]
     pub fn require_grad(self) -> Self {
         self.set_require_grad(true)
     }
 
-    /// Returns true if the tensor requires gradients during the backward pass.
+    /// Returns whether this tensor's gradient is retained after backward.
+    ///
+    /// This is distinct from [`Tensor::is_autodiff`], which reports whether operations use an
+    /// autodiff context, and `Tensor::is_tracked()`, which reports graph participation when the
+    /// `autodiff` feature is enabled.
     pub fn is_require_grad(&self) -> bool {
         is_require_grad_impl(&self.primitive)
     }
 
-    /// Mark the tensor as tracked or untracked depending on the require_grad argument.
-    /// When tracked, the gradients will be available after the backward pass.
+    /// Sets whether this tensor's gradient is retained after backward.
     ///
-    /// This function does nothing when autodiff is not enabled.
+    /// This function does nothing when autodiff isn't enabled or when the tensor is quantized.
+    /// Setting this to `false` on a non-leaf tensor starts a new graph lineage, like
+    /// [`detach`](Tensor::detach), while leaving gradient retention disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics when setting this to `true` on a non-leaf tensor.
+    #[must_use]
     pub fn set_require_grad(self, require_grad: bool) -> Self {
         Self::new(set_require_grad_impl(self.primitive, require_grad))
     }

--- a/crates/burn/tests/autodiff_context.rs
+++ b/crates/burn/tests/autodiff_context.rs
@@ -6,11 +6,16 @@ use burn::tensor::{Device, GradientCheckpointingStrategy, Tensor, TensorData};
 
 #[test]
 fn gradient_flows_to_enabled_operand_but_not_disabled_constant() {
-    let x = Tensor::<1>::from_floats([2.0, 3.0], &Device::flex().autodiff()).require_grad();
+    let x = Tensor::<1>::from_floats([2.0, 3.0], &Device::flex().autodiff());
+    assert!(x.is_autodiff());
+    assert!(!x.is_tracked());
+
+    let x = x.require_grad();
     let constant = Tensor::<1>::from_floats([4.0, 5.0], &Device::flex());
 
     let output = (x.clone() * constant.clone()).sum();
-    assert!(output.device().is_autodiff());
+    assert!(output.is_autodiff());
+    assert!(output.is_tracked());
 
     let grads = output.backward();
     x.grad(&grads)
@@ -20,8 +25,50 @@ fn gradient_flows_to_enabled_operand_but_not_disabled_constant() {
 
     // Context merging is operation-local: the concrete operand is neither mutated nor added to
     // the graph, and remains unavailable as a gradient target.
-    assert!(!constant.device().is_autodiff());
+    assert!(!constant.is_autodiff());
+    assert!(!constant.is_tracked());
     assert!(!constant.is_require_grad());
+    assert!(constant.grad(&grads).is_none());
+}
+
+#[test]
+fn autodiff_and_tracking_states_follow_graph_transitions() {
+    let plain = Tensor::<1>::from_floats([1.0, 2.0], &Device::flex());
+    assert!(!plain.is_autodiff());
+    assert!(!plain.is_tracked());
+    assert!(!plain.is_require_grad());
+
+    let autodiff = plain.autodiff();
+    assert!(autodiff.is_autodiff());
+    assert!(!autodiff.is_tracked());
+    assert!(!autodiff.is_require_grad());
+
+    let leaf = autodiff.require_grad();
+    assert!(leaf.is_autodiff());
+    assert!(leaf.is_tracked());
+    assert!(leaf.is_require_grad());
+
+    // Detaching a leaf preserves its gradient-retention setting and starts a new tracked leaf.
+    let detached_leaf = leaf.clone().detach();
+    assert!(detached_leaf.is_autodiff());
+    assert!(detached_leaf.is_tracked());
+    assert!(detached_leaf.is_require_grad());
+
+    let derived = leaf.mul_scalar(2.0);
+    assert!(derived.is_autodiff());
+    assert!(derived.is_tracked());
+    assert!(!derived.is_require_grad());
+
+    // A detached non-leaf stays in the autodiff context but has no recorded graph.
+    let detached = derived.clone().detach();
+    assert!(detached.is_autodiff());
+    assert!(!detached.is_tracked());
+    assert!(!detached.is_require_grad());
+
+    let plain = derived.without_autodiff();
+    assert!(!plain.is_autodiff());
+    assert!(!plain.is_tracked());
+    assert!(!plain.is_require_grad());
 }
 
 #[test]
@@ -29,16 +76,16 @@ fn tensor_autodiff_conversions_are_idempotent() {
     let plain = Tensor::<1>::from_floats([1.0, 2.0], &Device::flex());
 
     let plain = plain.without_autodiff().inner();
-    assert!(!plain.device().is_autodiff());
+    assert!(!plain.is_autodiff());
 
     let autodiff = plain.autodiff();
-    assert!(autodiff.device().is_autodiff());
+    assert!(autodiff.is_autodiff());
 
     let autodiff = Tensor::from_inner(autodiff);
-    assert!(autodiff.device().is_autodiff());
+    assert!(autodiff.is_autodiff());
 
     let plain = autodiff.without_autodiff().inner();
-    assert!(!plain.device().is_autodiff());
+    assert!(!plain.is_autodiff());
 }
 
 #[test]
@@ -48,13 +95,51 @@ fn enabling_autodiff_twice_preserves_checkpointing_strategy() {
 
     let tensor = tensor.autodiff();
     assert_eq!(
-        tensor.device().gradient_checkpointing_strategy(),
-        GradientCheckpointingStrategy::Balanced
+        tensor.gradient_checkpointing_strategy(),
+        Some(GradientCheckpointingStrategy::Balanced)
     );
 
     let tensor = Tensor::from_inner(tensor);
     assert_eq!(
-        tensor.device().gradient_checkpointing_strategy(),
-        GradientCheckpointingStrategy::Balanced
+        tensor.gradient_checkpointing_strategy(),
+        Some(GradientCheckpointingStrategy::Balanced)
     );
+}
+
+#[test]
+fn device_autodiff_conversions_are_idempotent() {
+    let device = Device::flex()
+        .autodiff()
+        .gradient_checkpointing()
+        .autodiff();
+
+    assert!(device.is_autodiff());
+    assert_eq!(
+        device.gradient_checkpointing_strategy(),
+        Some(GradientCheckpointingStrategy::Balanced)
+    );
+
+    let device = device.without_autodiff().inner();
+    assert!(!device.is_autodiff());
+    assert_eq!(device.gradient_checkpointing_strategy(), None);
+}
+
+#[test]
+fn tensor_autodiff_builder_configures_checkpointing() {
+    let tensor = Tensor::<1>::from_floats([1.0, 2.0], &Device::flex())
+        .autodiff()
+        .with_gradient_checkpointing_strategy(GradientCheckpointingStrategy::Balanced);
+
+    assert!(tensor.is_autodiff());
+    assert_eq!(
+        tensor.gradient_checkpointing_strategy(),
+        Some(GradientCheckpointingStrategy::Balanced)
+    );
+}
+
+#[test]
+#[should_panic(expected = "Tensor::with_gradient_checkpointing_strategy requires autodiff")]
+fn tensor_checkpointing_strategy_setter_requires_autodiff() {
+    let _ = Tensor::<1>::from_floats([1.0, 2.0], &Device::flex())
+        .with_gradient_checkpointing_strategy(GradientCheckpointingStrategy::Balanced);
 }

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -216,7 +216,10 @@ mod checkpoint_strategy_routing {
             let output = Tensor::<1>::from_dispatch(output);
 
             assert_eq!(EXECUTED_STRATEGY.load(Ordering::SeqCst), expected);
-            assert_eq!(output.device().gradient_checkpointing_strategy(), strategy);
+            assert_eq!(
+                output.device().gradient_checkpointing_strategy(),
+                Some(strategy)
+            );
         }
     }
 
@@ -230,7 +233,10 @@ mod checkpoint_strategy_routing {
 
         let output = <Dispatch as StrategyBackend>::add(lhs.into_dispatch(), rhs.into_dispatch());
         let output = Tensor::<1>::from_dispatch(output);
-        assert_eq!(output.device().gradient_checkpointing_strategy(), strategy);
+        assert_eq!(
+            output.device().gradient_checkpointing_strategy(),
+            Some(strategy)
+        );
         output
             .into_data()
             .assert_eq(&burn::tensor::TensorData::from([3.0f32]), true);
@@ -317,7 +323,7 @@ mod extension_context_contract {
 
         assert_eq!(
             output.device().gradient_checkpointing_strategy(),
-            GradientCheckpointingStrategy::Balanced
+            Some(GradientCheckpointingStrategy::Balanced)
         );
     }
 
@@ -334,7 +340,7 @@ mod extension_context_contract {
 
         assert_eq!(
             output.device().gradient_checkpointing_strategy(),
-            GradientCheckpointingStrategy::Balanced
+            Some(GradientCheckpointingStrategy::Balanced)
         );
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Changes

Clarifies runtime autodiff UX by adding `Tensor::is_autodiff()` and `Tensor::is_tracked()`, refining tensor/device context transitions and checkpointing APIs, and documenting the distinction between autodiff association, graph participation, and gradient retention.

### Testing

Added regression coverage for mixed contexts, device transfers, and graph-state transitions.
