### PR TITLE
fix(pack): validate tensor byte lengths when reading

### DIFF
--- a/crates/burn-pack/src/base.rs
+++ b/crates/burn-pack/src/base.rs
@@ -311,6 +311,40 @@ pub(crate) struct TensorDescriptor {
     pub param_id: Option<u64>,
 }
 
+/// Validate that a tensor's byte range agrees with its declared shape and dtype.
+///
+/// Quantized tensors are exempt because their packed values and inline scales don't follow the
+/// ordinary `num_elements * dtype_size` layout.
+pub(crate) fn validate_tensor_byte_len(
+    name: &str,
+    dtype: DType,
+    shape: &[u64],
+    data_len: u64,
+) -> Result<(), Error> {
+    if matches!(dtype, DType::QFloat(_)) {
+        return Ok(());
+    }
+
+    let num_elements = shape
+        .iter()
+        .try_fold(1u64, |total, &dimension| total.checked_mul(dimension));
+    let expected = num_elements
+        .and_then(|num_elements| num_elements.checked_mul(dtype.size() as u64))
+        .ok_or_else(|| {
+            Error::ValidationError(format!(
+                "tensor '{name}' byte length calculation overflows u64 for shape {shape:?} and dtype {dtype:?}"
+            ))
+        })?;
+
+    if data_len != expected {
+        return Err(Error::ValidationError(format!(
+            "tensor '{name}' declares {data_len} bytes but its shape {shape:?} and dtype {dtype:?} need {expected}"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Error types for Burnpack operations
 #[derive(Debug)]
 pub enum Error {

--- a/crates/burn-pack/src/reader.rs
+++ b/crates/burn-pack/src/reader.rs
@@ -1,6 +1,7 @@
 use super::base::{
     Error, FORMAT_VERSION, HEADER_SIZE, Header, MAX_CBOR_RECURSION_DEPTH, MAX_METADATA_SIZE,
     MAX_TENSOR_COUNT, MAX_TENSOR_SIZE, Metadata, TensorDescriptor, aligned_data_section_start,
+    validate_tensor_byte_len,
 };
 use super::tensor::Tensor;
 use alloc::format;
@@ -287,21 +288,21 @@ fn validate_total_size(
     data_offset: usize,
     available: usize,
 ) -> Result<(), Error> {
-    if metadata.tensors.is_empty() {
-        return Ok(());
+    let mut min_size = None;
+    for (name, descriptor) in &metadata.tensors {
+        let (start, end) = tensor_range(data_offset, name, descriptor)?;
+        validate_tensor_byte_len(
+            name,
+            descriptor.dtype,
+            &descriptor.shape,
+            (end - start) as u64,
+        )?;
+        min_size = Some(min_size.map_or(end, |current: usize| current.max(end)));
     }
-    let max_offset = metadata
-        .tensors
-        .values()
-        .map(|t| t.data_offsets.1)
-        .max()
-        .unwrap_or(0);
-    let max_offset: usize = max_offset.try_into().map_err(|_| {
-        Error::ValidationError(format!("Data offset {max_offset} exceeds platform maximum"))
-    })?;
-    let min_size = data_offset
-        .checked_add(max_offset)
-        .ok_or_else(|| Error::ValidationError("File size calculation overflow".into()))?;
+
+    let Some(min_size) = min_size else {
+        return Ok(());
+    };
     if available < min_size {
         return Err(Error::ValidationError(format!(
             "File truncated: expected at least {min_size} bytes, got {available} bytes"
@@ -367,6 +368,7 @@ fn io_err(e: std::io::Error) -> Error {
 mod tests {
     use super::*;
     use crate::{TENSOR_ALIGNMENT, Tensor, Writer};
+    use alloc::collections::BTreeMap;
     use burn_std::DType;
 
     fn tensor(name: &str, elems: usize) -> Tensor {
@@ -377,6 +379,43 @@ mod tests {
             None,
             Bytes::from_bytes_vec(alloc::vec![0u8; elems * 4]),
         )
+    }
+
+    fn pack_with_descriptor(shape: Vec<u64>, data_len: u64) -> Bytes {
+        let mut tensors = BTreeMap::new();
+        tensors.insert(
+            "weight".to_string(),
+            TensorDescriptor {
+                dtype: DType::F32,
+                shape,
+                data_offsets: (0, data_len),
+                param_id: None,
+            },
+        );
+        let metadata = Metadata {
+            tensors,
+            metadata: BTreeMap::new(),
+            scalars: BTreeMap::new(),
+        };
+        let mut metadata_bytes = Vec::new();
+        ciborium::ser::into_writer(&metadata, &mut metadata_bytes).unwrap();
+        let header = Header::new(metadata_bytes.len() as u32);
+        let data_offset = aligned_data_section_start(metadata_bytes.len());
+
+        let mut bytes = header.into_bytes().to_vec();
+        bytes.extend(metadata_bytes);
+        bytes.resize(data_offset + data_len as usize, 0);
+        Bytes::from_bytes_vec(bytes)
+    }
+
+    fn assert_byte_length_error(bytes: Bytes, expected: &str) {
+        match Reader::from_bytes(bytes) {
+            Err(Error::ValidationError(message)) => assert!(
+                message.contains(expected),
+                "expected error containing {expected:?}, got {message:?}"
+            ),
+            _ => panic!("expected a byte-length validation error"),
+        }
     }
 
     #[test]
@@ -394,5 +433,23 @@ mod tests {
                 "tensor '{name}' start offset is not 256-aligned"
             );
         }
+    }
+
+    #[test]
+    fn rejects_tensor_data_shorter_than_declared_shape() {
+        assert_byte_length_error(pack_with_descriptor(vec![2, 3], 16), "need 24");
+    }
+
+    #[test]
+    fn rejects_tensor_data_longer_than_declared_shape() {
+        assert_byte_length_error(pack_with_descriptor(vec![2, 3], 32), "need 24");
+    }
+
+    #[test]
+    fn rejects_tensor_byte_length_overflow() {
+        assert_byte_length_error(
+            pack_with_descriptor(vec![u64::MAX, 2], 0),
+            "calculation overflows u64",
+        );
     }
 }

--- a/crates/burn-pack/src/writer.rs
+++ b/crates/burn-pack/src/writer.rs
@@ -1,6 +1,6 @@
 use super::base::{
     Error, FORMAT_VERSION, HEADER_SIZE, Header, MAGIC_NUMBER, Metadata, Scalar, TENSOR_ALIGNMENT,
-    TensorDescriptor, aligned_data_section_start,
+    TensorDescriptor, aligned_data_section_start, validate_tensor_byte_len,
 };
 use super::tensor::Tensor;
 #[cfg(feature = "std")]
@@ -10,7 +10,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
-use burn_std::{Bytes, DType, Shape};
+use burn_std::Bytes;
 
 #[cfg(feature = "std")]
 use std::fs::File;
@@ -296,10 +296,10 @@ impl Writer {
         for tensor in &self.tensors {
             let name = &tensor.name;
             let dtype = tensor.dtype;
-            let shape = &tensor.shape;
+            let shape: Vec<u64> = tensor.shape.iter().map(|&size| size as u64).collect();
             let data_len = tensor.byte_len() as u64;
 
-            Self::check_byte_len(name, dtype, shape, data_len)?;
+            validate_tensor_byte_len(name, dtype, &shape, data_len)?;
 
             // Align the start offset for mmap zero-copy support.
             let aligned_start = align_offset(current_offset, TENSOR_ALIGNMENT);
@@ -318,7 +318,7 @@ impl Writer {
                     name.clone(),
                     TensorDescriptor {
                         dtype,
-                        shape: shape.iter().map(|&s| s as u64).collect(),
+                        shape,
                         data_offsets: (aligned_start, end),
                         param_id: tensor.param_id,
                     },
@@ -339,34 +339,6 @@ impl Writer {
         }
 
         Ok((tensors, placements, current_offset as usize))
-    }
-
-    /// Reject a `byte_len` that cannot describe the tensor the entry declares.
-    ///
-    /// A reader sizes a tensor's [`Bytes`] from the descriptor's shape and
-    /// dtype, so a length that disagrees with them produces a container that reads back
-    /// wrong rather than one that fails to write. Catching it during planning costs nothing
-    /// and keeps the mistake from reaching a file at all.
-    ///
-    /// Quantized data is the deliberate exception: values are bit-packed and the scales are
-    /// appended inline, so its length is not `num_elements * dtype.size()`. That layout
-    /// contract belongs to the quantization layer, and burn-pack deliberately does not
-    /// reimplement it - which is why [`Tensor::deferred`] takes a byte length the
-    /// producer supplies rather than something derived here.
-    fn check_byte_len(name: &str, dtype: DType, shape: &Shape, data_len: u64) -> Result<(), Error> {
-        if matches!(dtype, DType::QFloat(_)) {
-            return Ok(());
-        }
-
-        let expected = shape.num_elements() as u64 * dtype.size() as u64;
-        if data_len != expected {
-            return Err(Error::ValidationError(format!(
-                "tensor '{}' declares {} bytes but its shape {} and dtype {:?} need {}",
-                name, data_len, shape, dtype, expected
-            )));
-        }
-
-        Ok(())
     }
 
     /// Emit the full container — header, metadata, alignment padding, then tensor data

--- a/crates/burn-pack/tests/lazy_writer.rs
+++ b/crates/burn-pack/tests/lazy_writer.rs
@@ -180,7 +180,8 @@ fn a_quantized_byte_len_is_not_shape_checked_at_plan_time() {
     entry.values.truncate(2);
     entry.declared_len = 8;
 
-    Writer::new(vec![entry.build()]).into_bytes().unwrap();
+    let bytes = Writer::new(vec![entry.build()]).into_bytes().unwrap();
+    Reader::from_bytes(bytes).unwrap();
 }
 
 /// A `byte_len` consistent with the shape but a provider that produces something else slips


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5413.

### Changes

- Validate each non-quantized tensor byte range against its declared shape and dtype while opening a burnpack.
- Share the checked byte-length calculation between the reader and writer.
- Reject shape-size arithmetic overflow and preserve the packed `QFloat` exemption.
- Add regressions for ranges that are too short, too long, or overflow.

### Testing

- `cargo run-checks`
- `cargo test -p burn-pack`
- `cargo clippy -p burn-pack --all-targets -- -D warnings`
- `cargo check -p burn-pack --no-default-features`