### PR TITLE
fix(train): exclude padded samples from accuracy aggregation

### DIFF
--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -52,20 +52,20 @@ impl Metric for AccuracyMetric {
 
         let outputs = outputs.argmax(1).reshape([batch_size]);
 
-        let accuracy = match self.pad_token {
+        let (num_matches, num_pad) = match self.pad_token {
             Some(pad_token) => {
                 let mask = targets.clone().equal_scalar(pad_token as i64);
                 let matches = outputs.equal(targets).float().mask_fill(mask.clone(), 0);
-                let num_pad = mask.float().sum();
+                let num_pad = mask.int().sum().into_scalar::<i64>() as usize;
 
-                let acc = matches.sum() / (num_pad.neg() + batch_size as f32);
-
-                acc.into_scalar::<f64>()
+                (matches.sum().into_scalar::<f64>(), num_pad)
             }
-            None => outputs.equal(targets).int().sum().into_scalar::<f64>() / batch_size as f64,
+            None => (outputs.equal(targets).int().sum().into_scalar::<f64>(), 0),
         };
+        let valid_count = batch_size - num_pad;
+        let accuracy = num_matches / valid_count as f64;
 
-        self.state.update(100.0 * accuracy, batch_size);
+        self.state.update(100.0 * accuracy, valid_count);
         self.state
             .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
     }
@@ -158,6 +158,55 @@ mod tests {
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
         assert_eq!(50.0, metric.value().unwrap().current());
+    }
+
+    #[test]
+    fn test_accuracy_epoch_aggregation_excludes_padding() {
+        let device = Default::default();
+        let mut metric = AccuracyMetric::new().with_pad_token(2);
+
+        // One valid, correct sample and three padding samples.
+        metric.update(
+            &AccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.1]], &device),
+                Tensor::from_data([0, 2, 2, 2], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+        // Four valid, incorrect samples.
+        metric.update(
+            &AccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1]; 4], &device),
+                Tensor::from_data([1, 1, 1, 1], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // One correct prediction out of five valid samples.
+        assert_eq!(20.0, metric.final_value().current());
+    }
+
+    #[test]
+    fn test_fully_padded_batch_does_not_poison_epoch_accuracy() {
+        let device = Default::default();
+        let mut metric = AccuracyMetric::new().with_pad_token(2);
+
+        metric.update(
+            &AccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1]; 2], &device),
+                Tensor::from_data([2, 2], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+        metric.update(
+            &AccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1]], &device),
+                Tensor::from_data([0], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        assert_eq!(100.0, metric.final_value().current());
     }
 
     #[test]

--- a/crates/burn-train/src/metric/state.rs
+++ b/crates/burn-train/src/metric/state.rs
@@ -170,11 +170,15 @@ impl NumericMetricState {
     /// `count` is the number of underlying units `value` is averaged over.
     /// This is typically the batch size (e.g. for accuracy, loss), but it can be any
     /// unit the metric's `value` is implicitly a rate over.
+    /// A zero-count update records the current value without changing the running aggregate.
     pub fn update(&mut self, value: f64, count: usize) {
-        self.sum += value * count as f64;
-        self.count += count;
         self.current = value;
         self.current_count = count;
+
+        if count > 0 {
+            self.sum += value * count as f64;
+            self.count += count;
+        }
     }
 
     /// Compute the metric for the current update.

--- a/crates/burn-train/src/metric/top_k_acc.rs
+++ b/crates/burn-train/src/metric/top_k_acc.rs
@@ -65,11 +65,12 @@ impl Metric for TopKAccuracyMetric {
             Some(pad_token) => {
                 // we ignore the samples where the target is equal to the pad token
                 let mask = targets.clone().equal_scalar(pad_token as i64);
-                let num_pad = mask.clone().int().sum().into_scalar::<f64>();
+                let num_pad = mask.clone().int().sum().into_scalar::<i64>() as usize;
                 (targets.clone().mask_fill(mask, -1_i64), num_pad)
             }
-            None => (targets.clone(), 0_f64),
+            None => (targets.clone(), 0),
         };
+        let valid_count = batch_size - num_pad;
 
         let accuracy = targets
             .reshape([batch_size, 1])
@@ -78,9 +79,9 @@ impl Metric for TopKAccuracyMetric {
             .int()
             .sum()
             .into_scalar::<f64>()
-            / (batch_size as f64 - num_pad);
+            / valid_count as f64;
 
-        self.state.update(100.0 * accuracy, batch_size);
+        self.state.update(100.0 * accuracy, valid_count);
         self.state
             .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
     }
@@ -167,6 +168,32 @@ mod tests {
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
         assert_eq!(50.0, metric.value().unwrap().current());
+    }
+
+    #[test]
+    fn test_accuracy_epoch_aggregation_excludes_padding() {
+        let device = Default::default();
+        let mut metric = TopKAccuracyMetric::new(1).with_pad_token(2);
+
+        // One valid, correct sample and three padding samples.
+        metric.update(
+            &TopKAccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.1]], &device),
+                Tensor::from_data([0, 2, 2, 2], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+        // Four valid, incorrect samples.
+        metric.update(
+            &TopKAccuracyInput::new(
+                Tensor::from_data([[0.9, 0.1]; 4], &device),
+                Tensor::from_data([1, 1, 1, 1], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // One correct prediction out of five valid samples.
+        assert_eq!(20.0, metric.final_value().current());
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that cargo run-checks has been executed.
- [x] Made sure the book is up to date with changes in this PR; no book changes are needed.

### Related Issues/PRs

Fixes #5577

### Changes

- Weight AccuracyMetric and TopKAccuracyMetric epoch aggregation by non-padding samples.
- Prevent zero-valid-sample batches from changing the running numeric aggregate.
- Add multi-batch and fully padded regression coverage.

### Testing

- cargo run-checks
- cargo test -p burn-train metric:: --lib