### PR TITLE
feat(tensor): validate matmul rank in TensorCheck

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
@@ -466,6 +466,17 @@ fn float_should_panic_when_inner_dimensions_are_not_equal() {
 }
 
 #[test]
+#[should_panic(expected = "Matmul requires tensors with at least 2 dimensions")]
+fn float_should_panic_when_rank_is_less_than_2() {
+    let device = Default::default();
+    let tensor_1 = TestTensor::<1>::from_data([1., 2., 3.], &device);
+    let tensor_2 = TestTensor::<1>::from_data([4., 5., 6.], &device);
+
+    let tensor_3 = tensor_1.matmul(tensor_2);
+    tensor_3.into_data();
+}
+
+#[test]
 #[should_panic(expected = "Tensors are not broadcastable along batch dimension")]
 fn float_should_panic_when_batch_dimensions_are_not_broadcastable() {
     let device = Default::default();

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -477,7 +477,12 @@ impl TensorCheck {
         check = check.binary_ops_device("Matmul", &lhs.device(), &rhs.device());
 
         if D < 2 {
-            return check;
+            return check.register(
+                "Matmul",
+                TensorError::new(format!(
+                    "Matmul requires tensors with at least 2 dimensions, but got {D} dimension(s)."
+                )),
+            );
         }
 
         let shape_lhs = lhs.shape();


### PR DESCRIPTION
Resolves #5579

### Problem

`Tensor::matmul` is defined generically over `Tensor<D, K>`, so rank-1 inputs compile but have no matrix dimensions. `TensorCheck::matmul` short-circuits for `D < 2`, letting these invalid calls reach the backend, where they fail inconsistently:

- **ndarray**: panics with `attempt to subtract with overflow` (`shape_lhs[ndims - 2]` underflows when `ndims == 1`)
- **tch**: libtorch treats 1D x 1D `matmul` as a dot product and returns a 0-dim scalar, inconsistent with the `Tensor<1>` output rank
- **cubecl**: no valid kernel input

### Changes

- `TensorCheck::matmul` now registers a clear error for ranks < 2, mirroring the `tri()` check
- Regression test `float_should_panic_when_rank_is_less_than_2` in `burn-backend-tests/tests/tensor/float/ops/matmul.rs`

Verified against the ndarray backend: without the check, the new test fails with the backend overflow panic rather than the expected message.