### PR TITLE
feat(tensor): implement Min and Max scatter/select_assign across backends

### DIFF
--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1284,7 +1284,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         _checkpointer: &mut Checkpointer,
                     ) {
                         let (dim, data, values, indices, is_max) = ops.state;
-                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
 
                         let device = data.device();
                         let data_shape = data.shape();
@@ -1292,7 +1291,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         let settings = get_device_settings::<B>(&device);
                         let bool_dtype = settings.bool_dtype;
 
-                        let data_at_idx = B::float_gather(dim, data, indices_4lhs.clone().unwrap());
+                        let data_at_idx = B::float_gather(dim, data.clone(), indices.clone());
 
                         let (data_won_bool, values_won_bool) = if is_max {
                             (
@@ -1318,22 +1317,24 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         let values_won_float =
                             B::bool_into_float(values_won_bool, data_dtype.into());
 
-                        let ones = B::float_ones(data_shape, &device, data_dtype.into());
-                        let data_mask = B::float_scatter(
-                            dim,
-                            ones,
-                            indices_4lhs.unwrap(),
-                            data_won_float,
-                            IndexingUpdateOp::Assign,
-                        );
-
                         binary::<B, _, _>(
                             ops.parents,
                             ops.node,
                             grads,
-                            |grad| B::float_mul(grad, data_mask),
                             |grad| {
-                                let g_idx = B::float_gather(dim, grad, indices_4rhs.unwrap());
+                                let ones =
+                                    B::float_ones(data_shape.clone(), &device, data_dtype.into());
+                                let data_mask = B::float_scatter(
+                                    dim,
+                                    ones,
+                                    indices.clone(),
+                                    data_won_float,
+                                    IndexingUpdateOp::Assign,
+                                );
+                                B::float_mul(grad, data_mask)
+                            },
+                            |grad| {
+                                let g_idx = B::float_gather(dim, grad, indices.clone());
                                 B::float_mul(g_idx, values_won_float)
                             },
                         );
@@ -2118,7 +2119,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         let tensor: FloatTensor<B> =
                             checkpointer.retrieve_node_output(tensor_state);
                         let values: FloatTensor<B> = checkpointer.retrieve_node_output(value_state);
-                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
 
                         let device = tensor.device();
                         let tensor_shape = tensor.shape();
@@ -2126,8 +2126,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         let settings = get_device_settings::<B>(&device);
                         let bool_dtype = settings.bool_dtype;
 
-                        let data_at_idx =
-                            B::float_select(tensor, dim, indices_4lhs.clone().unwrap());
+                        let data_at_idx = B::float_select(tensor, dim, indices.clone());
 
                         let (data_won_bool, values_won_bool) = if is_max {
                             (
@@ -2153,22 +2152,27 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         let values_won_float =
                             B::bool_into_float(values_won_bool, tensor_dtype.into());
 
-                        let ones = B::float_ones(tensor_shape, &device, tensor_dtype.into());
-                        let data_mask = B::float_select_assign(
-                            ones,
-                            dim,
-                            indices_4lhs.unwrap(),
-                            data_won_float,
-                            IndexingUpdateOp::Assign,
-                        );
-
                         binary::<B, _, _>(
                             ops.parents,
                             ops.node,
                             grads,
-                            |grad| B::float_mul(grad, data_mask),
                             |grad| {
-                                let g_idx = B::float_select(grad, dim, indices_4rhs.unwrap());
+                                let ones = B::float_ones(
+                                    tensor_shape.clone(),
+                                    &device,
+                                    tensor_dtype.into(),
+                                );
+                                let data_mask = B::float_select_assign(
+                                    ones,
+                                    dim,
+                                    indices.clone(),
+                                    data_won_float,
+                                    IndexingUpdateOp::Assign,
+                                );
+                                B::float_mul(grad, data_mask)
+                            },
+                            |grad| {
+                                let g_idx = B::float_select(grad, dim, indices.clone());
                                 B::float_mul(g_idx, values_won_float)
                             },
                         );

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1259,7 +1259,113 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     )),
                 }
             }
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+            IndexingUpdateOp::Min | IndexingUpdateOp::Max => {
+                // Unique indices are required for this backward formula; duplicate indices have
+                // undefined behavior (same caveat as float_scatter_nd Min/Max).
+                // Forward (Max): out[.., idx, ..] = max(data[.., idx, ..], values[.., i, ..]).
+                // Backward, with ties contributing to both sides (matches the cummin/cummax
+                // convention):
+                //   data_at_idx  = gather(data, dim, idx)
+                //   data_won     = data_at_idx >= values   (Max) / <= values (Min)
+                //   values_won   = values >= data_at_idx   (Max) / <= data_at_idx (Min)
+                //   data_mask    = scatter(ones_like(data), dim, idx, data_won, Assign)
+                //   grad_data    = grad * data_mask
+                //   grad_values  = gather(grad, dim, idx) * values_won
+                #[derive(Debug)]
+                struct ScatterMinMax;
+
+                impl<B: Backend> Backward<B, 2> for ScatterMinMax {
+                    type State = (usize, FloatTensor<B>, FloatTensor<B>, IntTensor<B>, bool);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, data, values, indices, is_max) = ops.state;
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        let device = data.device();
+                        let data_shape = data.shape();
+                        let data_dtype = data.dtype();
+                        let settings = get_device_settings::<B>(&device);
+                        let bool_dtype = settings.bool_dtype;
+
+                        let data_at_idx = B::float_gather(dim, data, indices_4lhs.clone().unwrap());
+
+                        let (data_won_bool, values_won_bool) = if is_max {
+                            (
+                                B::float_greater_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_greater_equal(values, data_at_idx, bool_dtype),
+                            )
+                        } else {
+                            (
+                                B::float_lower_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_lower_equal(values, data_at_idx, bool_dtype),
+                            )
+                        };
+
+                        let data_won_float = B::bool_into_float(data_won_bool, data_dtype.into());
+                        let values_won_float =
+                            B::bool_into_float(values_won_bool, data_dtype.into());
+
+                        let ones = B::float_ones(data_shape, &device, data_dtype.into());
+                        let data_mask = B::float_scatter(
+                            dim,
+                            ones,
+                            indices_4lhs.unwrap(),
+                            data_won_float,
+                            IndexingUpdateOp::Assign,
+                        );
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| B::float_mul(grad, data_mask),
+                            |grad| {
+                                let g_idx = B::float_gather(dim, grad, indices_4rhs.unwrap());
+                                B::float_mul(g_idx, values_won_float)
+                            },
+                        );
+                    }
+                }
+
+                let is_max = matches!(update, IndexingUpdateOp::Max);
+
+                match ScatterMinMax
+                    .prepare::<C>([tensor.node, value.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        (
+                            dim,
+                            tensor.primitive.clone(),
+                            value.primitive.clone(),
+                            indices.clone(),
+                            is_max,
+                        ),
+                        B::float_scatter(dim, tensor.primitive, indices, value.primitive, update),
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter(
+                        dim,
+                        tensor.primitive,
+                        indices,
+                        value.primitive,
+                        update,
+                    )),
+                }
+            }
         }
     }
 
@@ -1960,8 +2066,152 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     )),
                 }
             }
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            IndexingUpdateOp::Min | IndexingUpdateOp::Max => {
+                // Unique indices are required for this backward formula; duplicate indices have
+                // undefined behavior (same caveat as float_scatter_nd Min/Max).
+                // Forward (Max): out[.., idx, ..] = max(tensor[.., idx, ..], values[.., i, ..]).
+                // Backward, with ties contributing to both sides (matches the cummin/cummax
+                // convention):
+                //   data_at_idx  = select(tensor, dim, indices)
+                //   data_won     = data_at_idx >= values   (Max) / <= values (Min)
+                //   values_won   = values >= data_at_idx   (Max) / <= data_at_idx (Min)
+                //   data_mask    = select_assign(ones_like(tensor), dim, idx, data_won, Assign)
+                //   grad_tensor  = grad * data_mask
+                //   grad_values  = select(grad, dim, idx) * values_won
+                #[derive(Debug)]
+                struct IndexSelectDimAssignMinMax;
+
+                #[derive(new, Debug)]
+                struct RetroSelectAssignMinMax<B: Backend> {
+                    tensor_id: NodeId,
+                    dim: usize,
+                    indices: IntTensor<B>,
+                    value_id: NodeId,
+                    update: IndexingUpdateOp,
+                }
+
+                impl<B: Backend> RetroForward for RetroSelectAssignMinMax<B> {
+                    fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
+                        let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
+                        let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
+                        let out = B::float_select_assign(
+                            tensor,
+                            self.dim,
+                            self.indices.clone(),
+                            value,
+                            self.update,
+                        );
+                        states.save(out_node, out)
+                    }
+                }
+
+                impl<B: Backend> Backward<B, 2> for IndexSelectDimAssignMinMax {
+                    type State = (usize, NodeId, NodeId, IntTensor<B>, bool);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, tensor_state, value_state, indices, is_max) = ops.state;
+                        let tensor: FloatTensor<B> =
+                            checkpointer.retrieve_node_output(tensor_state);
+                        let values: FloatTensor<B> = checkpointer.retrieve_node_output(value_state);
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        let device = tensor.device();
+                        let tensor_shape = tensor.shape();
+                        let tensor_dtype = tensor.dtype();
+                        let settings = get_device_settings::<B>(&device);
+                        let bool_dtype = settings.bool_dtype;
+
+                        let data_at_idx =
+                            B::float_select(tensor, dim, indices_4lhs.clone().unwrap());
+
+                        let (data_won_bool, values_won_bool) = if is_max {
+                            (
+                                B::float_greater_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_greater_equal(values, data_at_idx, bool_dtype),
+                            )
+                        } else {
+                            (
+                                B::float_lower_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_lower_equal(values, data_at_idx, bool_dtype),
+                            )
+                        };
+
+                        let data_won_float = B::bool_into_float(data_won_bool, tensor_dtype.into());
+                        let values_won_float =
+                            B::bool_into_float(values_won_bool, tensor_dtype.into());
+
+                        let ones = B::float_ones(tensor_shape, &device, tensor_dtype.into());
+                        let data_mask = B::float_select_assign(
+                            ones,
+                            dim,
+                            indices_4lhs.unwrap(),
+                            data_won_float,
+                            IndexingUpdateOp::Assign,
+                        );
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| B::float_mul(grad, data_mask),
+                            |grad| {
+                                let g_idx = B::float_select(grad, dim, indices_4rhs.unwrap());
+                                B::float_mul(g_idx, values_won_float)
+                            },
+                        );
+                    }
+                }
+
+                let is_max = matches!(update, IndexingUpdateOp::Max);
+
+                match IndexSelectDimAssignMinMax
+                    .prepare::<C>([tensor.node.clone(), value.node.clone()])
+                    .memory_bound()
+                    .retro_forward(RetroSelectAssignMinMax::<B>::new(
+                        tensor.node.id,
+                        dim,
+                        indices.clone(),
+                        value.node.id,
+                        update,
+                    ))
+                    .parents([&tensor, &value])
+                    .stateful()
+                {
+                    OpsKind::Tracked(mut prep) => {
+                        let tensor_state = prep.checkpoint(&tensor);
+                        let value_state = prep.checkpoint(&value);
+                        prep.finish(
+                            (dim, tensor_state, value_state, indices.clone(), is_max),
+                            B::float_select_assign(
+                                tensor.primitive,
+                                dim,
+                                indices,
+                                value.primitive,
+                                update,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_select_assign(
+                        tensor.primitive,
+                        dim,
+                        indices,
+                        value.primitive,
+                        update,
+                    )),
+                }
             }
         }
     }

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -226,3 +226,42 @@ fn test_scatter_min_grad() {
         .to_data()
         .assert_eq(&TensorData::from([0.0, 1.0]), false);
 }
+
+#[test]
+fn test_scatter_max_grad_values_only() {
+    // Only values require grad; the data mask must not be built.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<1>::from_data(TensorData::from([4.0, 2.0, 1.0, 5.0]), &device);
+    let values = TestTensor::from_data(TensorData::from([10.0, 3.0]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([1, 0]), &device);
+    let weights = TestTensor::from_data(TensorData::from([1.0, 2.0, 3.0, 4.0]), &device);
+
+    let result = tensor.scatter(0, indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.mul(weights).sum().backward();
+
+    // out[1] = max(2, 10) = 10 -> values win, grad flows to values[0].
+    // out[0] = max(4, 3) = 4 -> data wins, grad skipped for values[1].
+    let grad_values = values.grad(&grads).unwrap();
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([2.0, 0.0]), false);
+}
+
+#[test]
+fn test_scatter_min_grad_values_only() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<1>::from_data(TensorData::from([4.0, 2.0, 1.0, 5.0]), &device);
+    let values = TestTensor::from_data(TensorData::from([10.0, 3.0]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([1, 0]), &device);
+    let weights = TestTensor::from_data(TensorData::from([1.0, 2.0, 3.0, 4.0]), &device);
+
+    let result = tensor.scatter(0, indices, values.clone(), IndexingUpdateOp::Min);
+    let grads = result.mul(weights).sum().backward();
+
+    // out[1] = min(2, 10) = 2 -> data wins, grad skipped for values[0].
+    // out[0] = min(4, 3) = 3 -> values win, grad flows to values[1].
+    let grad_values = values.grad(&grads).unwrap();
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([0.0, 1.0]), false);
+}

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -164,3 +164,65 @@ fn test_scatter_add_grad_partial_indices() {
         .to_data()
         .assert_eq(&TensorData::from([[1., 1., 1.]]), false);
 }
+
+#[test]
+fn test_scatter_max_grad() {
+    // Max: values win at tensor[1], data wins at tensor[0] (ties route to both).
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([4.0, 2.0, 1.0, 5.0]), &device).require_grad();
+    let values = TestTensor::from_data(TensorData::from([10.0, 3.0]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([1, 0]), &device);
+    let weights = TestTensor::from_data(TensorData::from([1.0, 2.0, 3.0, 4.0]), &device);
+
+    let result = tensor
+        .clone()
+        .scatter(0, indices, values.clone(), IndexingUpdateOp::Max);
+
+    result
+        .clone()
+        .into_data()
+        .assert_eq(&TensorData::from([4.0, 10.0, 1.0, 5.0]), false);
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .to_data()
+        .assert_eq(&TensorData::from([1.0, 0.0, 3.0, 4.0]), false);
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([2.0, 0.0]), false);
+}
+
+#[test]
+fn test_scatter_min_grad() {
+    // Min: data wins at tensor[1], values win at tensor[0].
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([4.0, 2.0, 1.0, 5.0]), &device).require_grad();
+    let values = TestTensor::from_data(TensorData::from([10.0, 3.0]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([1, 0]), &device);
+    let weights = TestTensor::from_data(TensorData::from([1.0, 2.0, 3.0, 4.0]), &device);
+
+    let result = tensor
+        .clone()
+        .scatter(0, indices, values.clone(), IndexingUpdateOp::Min);
+
+    result
+        .clone()
+        .into_data()
+        .assert_eq(&TensorData::from([3.0, 2.0, 1.0, 5.0]), false);
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .to_data()
+        .assert_eq(&TensorData::from([0.0, 2.0, 3.0, 4.0]), false);
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([0.0, 1.0]), false);
+}

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -311,3 +311,54 @@ fn test_select_assign_min_grad_values_win() {
         .into_data()
         .assert_eq(&TensorData::from([[3.0, 1.0], [6.0, 4.0]]), false);
 }
+
+#[test]
+fn test_select_assign_max_grad_values_only() {
+    // Only values require grad; the full-size data mask must not be built.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    );
+    let values = TestTensor::from_data(TensorData::from([[100.0, 100.0], [100.0, 100.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor.select_assign(1, indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.mul(weights).sum().backward();
+
+    // values win at tensor[.., 2] and tensor[.., 0].
+    let grad_values = values.grad(&grads).unwrap();
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 1.0], [6.0, 4.0]]), false);
+}
+
+#[test]
+fn test_select_assign_min_grad_values_only() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    );
+    let values =
+        TestTensor::from_data(TensorData::from([[1.0, 1.0], [1.0, 1.0]]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor.select_assign(1, indices, values.clone(), IndexingUpdateOp::Min);
+    let grads = result.mul(weights).sum().backward();
+
+    // values win at tensor[.., 2] and tensor[.., 0].
+    let grad_values = values.grad(&grads).unwrap();
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 1.0], [6.0, 4.0]]), false);
+}

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -157,3 +157,157 @@ fn test_select_add_grad_different_shapes() {
         .into_data()
         .assert_eq(&TensorData::from([[5.0], [5.0]]), false);
 }
+
+#[test]
+fn test_select_assign_max_grad_data_wins() {
+    // Max: data > values everywhere, so grad flows fully through tensor.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values =
+        TestTensor::from_data(TensorData::from([[1.0, 1.0], [1.0, 1.0]]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Max);
+
+    result
+        .clone()
+        .into_data()
+        .assert_eq(&TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]), false);
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .into_data()
+        .assert_eq(&TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), false);
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 0.0], [0.0, 0.0]]), false);
+}
+
+#[test]
+fn test_select_assign_max_grad_values_win() {
+    // Max: values win at the scattered positions (tensor[.., 2] and tensor[.., 0]),
+    // so their gradient is zeroed in grad_tensor and flows to grad_values.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[100.0, 100.0], [100.0, 100.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Max);
+
+    result.clone().into_data().assert_eq(
+        &TensorData::from([[100.0, 3.0, 100.0], [100.0, 6.0, 100.0]]),
+        false,
+    );
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 2.0, 0.0], [0.0, 5.0, 0.0]]), false);
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 1.0], [6.0, 4.0]]), false);
+}
+
+#[test]
+fn test_select_assign_min_grad_data_wins() {
+    // Min: data < values everywhere, so grad flows fully through tensor.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[100.0, 100.0], [100.0, 100.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Min);
+
+    result
+        .clone()
+        .into_data()
+        .assert_eq(&TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]), false);
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .into_data()
+        .assert_eq(&TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), false);
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 0.0], [0.0, 0.0]]), false);
+}
+
+#[test]
+fn test_select_assign_min_grad_values_win() {
+    // Min: values win at the scattered positions (tensor[.., 2] and tensor[.., 0]),
+    // so their gradient is zeroed in grad_tensor and flows to grad_values.
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values =
+        TestTensor::from_data(TensorData::from([[1.0, 1.0], [1.0, 1.0]]), &device).require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Min);
+
+    result
+        .clone()
+        .into_data()
+        .assert_eq(&TensorData::from([[1.0, 3.0, 1.0], [1.0, 6.0, 1.0]]), false);
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 2.0, 0.0], [0.0, 5.0, 0.0]]), false);
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 1.0], [6.0, 4.0]]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -161,6 +161,36 @@ fn should_scatter_max_1d() {
 }
 
 #[test]
+fn should_scatter_min_1d_repeated_indices() {
+    let device = Default::default();
+    // index 1 receives 7 then 50 (keeps 7); index 0 receives 100 then 3 (keeps 3).
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0, 100.0, 3.0], &device);
+    let indices = TestTensorInt::from_ints([1, 1, 0, 0], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([3.0, 7.0, 30.0, 40.0]), false);
+}
+
+#[test]
+fn should_scatter_max_1d_repeated_indices() {
+    let device = Default::default();
+    // index 1 receives 7 then 50 (keeps 50); index 0 receives 100 then 3 (keeps 100).
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0, 100.0, 3.0], &device);
+    let indices = TestTensorInt::from_ints([1, 1, 0, 0], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Max);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([100.0, 50.0, 30.0, 40.0]), false);
+}
+
+#[test]
 fn should_scatter_mul_2d_dim0() {
     let device = Default::default();
     let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -133,6 +133,34 @@ fn should_scatter_mul_1d() {
 }
 
 #[test]
+fn should_scatter_min_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10.0, 7.0, 30.0, 40.0]), false);
+}
+
+#[test]
+fn should_scatter_max_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Max);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10.0, 20.0, 30.0, 50.0]), false);
+}
+
+#[test]
 fn should_scatter_mul_2d_dim0() {
     let device = Default::default();
     let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
@@ -143,6 +171,35 @@ fn should_scatter_mul_2d_dim0() {
 
     output.into_data().assert_eq(
         &TensorData::from([[40.0, 40.0, 180.0], [40.0, 250.0, 180.0]]),
+        false,
+    );
+}
+
+#[test]
+fn should_scatter_min_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
+}
+
+#[test]
+fn should_scatter_max_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[100.0, 1.0, 100.0], [1.0, 100.0, 1.0]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Max);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[10.0, 20.0, 30.0], [100.0, 100.0, 100.0]]),
         false,
     );
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -133,19 +133,6 @@ fn should_select_assign_mul_2d_dim1() {
 }
 
 #[test]
-fn should_select_assign_min_1d() {
-    let device = Default::default();
-    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
-    let values = TestTensor::from_data([7.0, 50.0], &device);
-    let indices = TestTensorInt::from_data(TensorData::from([1, 3]), &device);
-
-    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
-    let expected = TensorData::from([10.0, 7.0, 30.0, 40.0]);
-
-    output.into_data().assert_eq(&expected, false);
-}
-
-#[test]
 fn should_select_assign_max_1d() {
     let device = Default::default();
     let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
@@ -154,6 +141,34 @@ fn should_select_assign_max_1d() {
 
     let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
     let expected = TensorData::from([10.0, 20.0, 30.0, 50.0]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_min_1d_repeated_indices() {
+    let device = Default::default();
+    // index 0 receives 100 then 3 (keeps 3); index 1 receives 7 then 50 (keeps 7).
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([100.0, 3.0, 7.0, 50.0], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([0, 0, 1, 1]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
+    let expected = TensorData::from([3.0, 7.0, 30.0, 40.0]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_max_1d_repeated_indices() {
+    let device = Default::default();
+    // index 0 receives 100 then 3 (keeps 100); index 1 receives 7 then 50 (keeps 50).
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([100.0, 3.0, 7.0, 50.0], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([0, 0, 1, 1]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
+    let expected = TensorData::from([100.0, 50.0, 30.0, 40.0]);
 
     output.into_data().assert_eq(&expected, false);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -133,6 +133,58 @@ fn should_select_assign_mul_2d_dim1() {
 }
 
 #[test]
+fn should_select_assign_min_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([1, 3]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
+    let expected = TensorData::from([10.0, 7.0, 30.0, 40.0]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_max_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([1, 3]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
+    let expected = TensorData::from([10.0, 20.0, 30.0, 50.0]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_min_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[5.0, 70.0], [80.0, 1.0]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
+    let expected = TensorData::from([[10.0, 1.0], [30.0, 40.0], [5.0, 60.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_max_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[5.0, 70.0], [80.0, 1.0]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
+    let expected = TensorData::from([[80.0, 20.0], [30.0, 40.0], [50.0, 70.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
 fn should_select_add_1d_int() {
     let device = Default::default();
     let tensor = TestTensorInt::<1>::from_data([7, 8, 9], &device);

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -123,3 +123,45 @@ fn should_scatter_mul_2d_dim0_int() {
         .into_data()
         .assert_eq(&TensorData::from([[40, 40, 180], [40, 250, 180]]), false);
 }
+
+#[test]
+fn should_scatter_min_1d_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10, 7, 30, 40]), false);
+}
+
+#[test]
+fn should_scatter_max_1d_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Max);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10, 20, 30, 50]), false);
+}
+
+#[test]
+fn should_scatter_min_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+    let values = TestTensorInt::from_ints([[1, 2, 3], [4, 5, 6]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -153,6 +153,36 @@ fn should_scatter_max_1d_int() {
 }
 
 #[test]
+fn should_scatter_min_1d_int_repeated_indices() {
+    let device = Default::default();
+    // index 1 receives 7 then 50 (keeps 7); index 0 receives 100 then 3 (keeps 3).
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50, 100, 3], &device);
+    let indices = TestTensorInt::from_ints([1, 1, 0, 0], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Min);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([3, 7, 30, 40]), false);
+}
+
+#[test]
+fn should_scatter_max_1d_int_repeated_indices() {
+    let device = Default::default();
+    // index 1 receives 7 then 50 (keeps 50); index 0 receives 100 then 3 (keeps 100).
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50, 100, 3], &device);
+    let indices = TestTensorInt::from_ints([1, 1, 0, 0], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Max);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([100, 50, 30, 40]), false);
+}
+
+#[test]
 fn should_scatter_min_2d_dim0_int() {
     let device = Default::default();
     let tensor = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -92,6 +92,34 @@ fn should_select_assign_min_2d_dim0_int() {
 }
 
 #[test]
+fn should_select_assign_min_1d_int_repeated_indices() {
+    let device = Default::default();
+    // index 0 receives 100 then 3 (keeps 3); index 1 receives 7 then 50 (keeps 7).
+    let tensor = TestTensorInt::<1>::from_data([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_data([100, 3, 7, 50], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([0, 0, 1, 1]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
+    let expected = TensorData::from([3, 7, 30, 40]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_max_1d_int_repeated_indices() {
+    let device = Default::default();
+    // index 0 receives 100 then 3 (keeps 100); index 1 receives 7 then 50 (keeps 50).
+    let tensor = TestTensorInt::<1>::from_data([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_data([100, 3, 7, 50], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([0, 0, 1, 1]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
+    let expected = TensorData::from([100, 50, 30, 40]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
 fn should_select_assign_max_2d_dim0_int() {
     let device = Default::default();
     let tensor = TestTensorInt::<2>::from_data([[10, 20], [30, 40], [50, 60]], &device);

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -79,6 +79,32 @@ fn should_select_assign_mul_2d_dim1_int() {
 }
 
 #[test]
+fn should_select_assign_min_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_data([[10, 20], [30, 40], [50, 60]], &device);
+    let values = TestTensorInt::from_data([[5, 70], [80, 1]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Min);
+    let expected = TensorData::from([[10, 1], [30, 40], [5, 60]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn should_select_assign_max_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_data([[10, 20], [30, 40], [50, 60]], &device);
+    let values = TestTensorInt::from_data([[5, 70], [80, 1]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Max);
+    let expected = TensorData::from([[80, 20], [30, 40], [50, 70]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
 #[should_panic]
 fn should_panic_select_add_invalid_num_indices() {
     let device = Default::default();

--- a/crates/burn-cubecl/src/kernel/index/scatter.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::{
-        AddOp, AssignOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
+        AddOp, AssignOp, BinaryMaxOp, BinaryMinOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
         utils::{address_type, shape_divmod},
     },
     tensor::CubeTensor,
@@ -137,4 +137,22 @@ pub(crate) fn scatter_assign(
     value: CubeTensor,
 ) -> CubeTensor {
     scatter_op::<AssignOp>(dim, tensor, indices, value)
+}
+
+pub(crate) fn scatter_min(
+    dim: usize,
+    tensor: CubeTensor,
+    indices: CubeTensor,
+    value: CubeTensor,
+) -> CubeTensor {
+    scatter_op::<BinaryMinOp>(dim, tensor, indices, value)
+}
+
+pub(crate) fn scatter_max(
+    dim: usize,
+    tensor: CubeTensor,
+    indices: CubeTensor,
+    value: CubeTensor,
+) -> CubeTensor {
+    scatter_op::<BinaryMaxOp>(dim, tensor, indices, value)
 }

--- a/crates/burn-cubecl/src/kernel/index/select_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/select_assign.rs
@@ -1,5 +1,5 @@
 use crate::kernel::{
-    AddOp, AssignOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
+    AddOp, AssignOp, BinaryMaxOp, BinaryMinOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
     utils::{address_type, shape_divmod},
 };
 use crate::tensor::CubeTensor;
@@ -126,4 +126,22 @@ pub(crate) fn select_assign_replace(
     value: CubeTensor,
 ) -> CubeTensor {
     select_assign_op::<AssignOp>(tensor, dim, indices, value)
+}
+
+pub(crate) fn select_assign_min(
+    tensor: CubeTensor,
+    dim: usize,
+    indices: CubeTensor,
+    value: CubeTensor,
+) -> CubeTensor {
+    select_assign_op::<BinaryMinOp>(tensor, dim, indices, value)
+}
+
+pub(crate) fn select_assign_max(
+    tensor: CubeTensor,
+    dim: usize,
+    indices: CubeTensor,
+    value: CubeTensor,
+) -> CubeTensor {
+    select_assign_op::<BinaryMaxOp>(tensor, dim, indices, value)
 }

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -137,7 +137,12 @@ impl IntTensorOps<Self> for CubeBackend {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::scatter_mul(dim, tensor, indices, value)
             }
-            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                kernel::scatter_min(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                kernel::scatter_max(dim, tensor, indices, value)
+            }
         }
     }
 
@@ -179,8 +184,11 @@ impl IntTensorOps<Self> for CubeBackend {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::select_assign_mul(tensor, dim, indices, value)
             }
-            other => {
-                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                kernel::select_assign_min(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                kernel::select_assign_max(tensor, dim, indices, value)
             }
         }
     }

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -191,7 +191,12 @@ impl FloatTensorOps<Self> for CubeBackend {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::scatter_mul(dim, tensor, indices, value)
             }
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                kernel::scatter_min(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                kernel::scatter_max(dim, tensor, indices, value)
+            }
         }
     }
 
@@ -233,8 +238,11 @@ impl FloatTensorOps<Self> for CubeBackend {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::select_assign_mul(tensor, dim, indices, value)
             }
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                kernel::select_assign_min(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                kernel::select_assign_max(tensor, dim, indices, value)
             }
         }
     }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -335,7 +335,36 @@ impl FloatTensorOps<Flex> for Flex {
                 }
                 _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
             },
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::scatter_min::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::scatter_min::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::scatter_min::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::scatter_min::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
+            },
+            burn_backend::tensor::IndexingUpdateOp::Max => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::scatter_max::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::scatter_max::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::scatter_max::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::scatter_max::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
+            },
         }
     }
 
@@ -448,9 +477,42 @@ impl FloatTensorOps<Flex> for Flex {
                     tensor.dtype()
                 ),
             },
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
-            }
+            burn_backend::tensor::IndexingUpdateOp::Min => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::select_min::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::select_min::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::select_min::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::select_min::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!(
+                    "float_select_assign: unsupported dtype {:?}",
+                    tensor.dtype()
+                ),
+            },
+            burn_backend::tensor::IndexingUpdateOp::Max => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::select_max::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::select_max::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::select_max::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::select_max::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!(
+                    "float_select_assign: unsupported dtype {:?}",
+                    tensor.dtype()
+                ),
+            },
         }
     }
 

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -411,6 +411,48 @@ pub fn scatter_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E
     )
 }
 
+/// Scatter minimum: keeps the smaller of the tensor and value at each position.
+pub fn scatter_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    scatter_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "scatter_min",
+        |target, value| {
+            if value < *target {
+                *target = value;
+            }
+        },
+    )
+}
+
+/// Scatter maximum: keeps the larger of the tensor and value at each position.
+pub fn scatter_max<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    scatter_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "scatter_max",
+        |target, value| {
+            if value > *target {
+                *target = value;
+            }
+        },
+    )
+}
+
 fn scatter_update<E, F>(
     tensor: FlexTensor,
     dim: usize,
@@ -851,6 +893,48 @@ pub fn select_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E>
         value,
         "select_mul",
         |target, value| *target = *target * value,
+    )
+}
+
+/// Select minimum: keeps the smaller of the tensor and value at each position.
+pub fn select_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    select_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "select_min",
+        |target, value| {
+            if value < *target {
+                *target = value;
+            }
+        },
+    )
+}
+
+/// Select maximum: keeps the larger of the tensor and value at each position.
+pub fn select_max<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    select_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "select_max",
+        |target, value| {
+            if value > *target {
+                *target = value;
+            }
+        },
     )
 }
 

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -412,6 +412,9 @@ pub fn scatter_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E
 }
 
 /// Scatter minimum: keeps the smaller of the tensor and value at each position.
+///
+/// Comparisons follow IEEE semantics: an incoming NaN never replaces the current
+/// value, matching the `scatter_nd` Min reduction in this module.
 pub fn scatter_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
     tensor: FlexTensor,
     dim: usize,
@@ -433,6 +436,9 @@ pub fn scatter_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + S
 }
 
 /// Scatter maximum: keeps the larger of the tensor and value at each position.
+///
+/// Comparisons follow IEEE semantics: an incoming NaN never replaces the current
+/// value, matching the `scatter_nd` Max reduction in this module.
 pub fn scatter_max<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
     tensor: FlexTensor,
     dim: usize,
@@ -897,6 +903,9 @@ pub fn select_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E>
 }
 
 /// Select minimum: keeps the smaller of the tensor and value at each position.
+///
+/// Comparisons follow IEEE semantics: an incoming NaN never replaces the current
+/// value.
 pub fn select_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
     tensor: FlexTensor,
     dim: usize,
@@ -918,6 +927,9 @@ pub fn select_min<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Se
 }
 
 /// Select maximum: keeps the larger of the tensor and value at each position.
+///
+/// Comparisons follow IEEE semantics: an incoming NaN never replaces the current
+/// value.
 pub fn select_max<E: Element + Pod + Default + Copy + core::cmp::PartialOrd + Send + Sync>(
     tensor: FlexTensor,
     dim: usize,

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -224,7 +224,66 @@ impl IntTensorOps<Flex> for Flex {
                     dt => panic!("int_scatter: unsupported dtype {:?}", dt),
                 }
             }
-            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::scatter_min::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::scatter_min::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::scatter_min::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::scatter_min::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::scatter_min::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::scatter_min::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::scatter_min::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::scatter_min::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_scatter: unsupported dtype {:?}", dt),
+                }
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::scatter_max::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::scatter_max::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::scatter_max::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::scatter_max::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::scatter_max::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::scatter_max::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::scatter_max::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::scatter_max::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_scatter: unsupported dtype {:?}", dt),
+                }
+            }
         }
     }
 
@@ -409,8 +468,73 @@ impl IntTensorOps<Flex> for Flex {
                     dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
                 }
             }
-            other => {
-                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                debug_assert_eq!(
+                    tensor.dtype(),
+                    value.dtype(),
+                    "int_select_assign: dtype mismatch"
+                );
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::select_min::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::select_min::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::select_min::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::select_min::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::select_min::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::select_min::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::select_min::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::select_min::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
+                }
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                debug_assert_eq!(
+                    tensor.dtype(),
+                    value.dtype(),
+                    "int_select_assign: dtype mismatch"
+                );
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::select_max::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::select_max::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::select_max::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::select_max::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::select_max::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::select_max::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::select_max::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::select_max::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
+                }
             }
         }
     }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -317,6 +317,9 @@ where
         Self::scatter_extreme(dim, tensor, indices, value, |out, value| value > *out)
     }
 
+    /// Shared traversal for the Min/Max scatter variants. `replace` decides whether
+    /// the incoming value overwrites the destination; its comparison defines the
+    /// NaN handling, matching the `scatter_nd` Min/Max reductions.
     fn scatter_extreme<I: NdArrayElement, F>(
         dim: usize,
         mut tensor: SharedArray<E>,
@@ -345,9 +348,8 @@ where
 
         if shape_value != shape_indices {
             panic!(
-                "Invalid dimension: the shape of the index tensor should be the same as the value \
-                 tensor: Index {:?} value {:?}",
-                shape_indices, shape_value
+                "scatter_min/scatter_max: the indices and value tensors must have the same shape, \
+                 but got indices {shape_indices:?} and value {shape_value:?}"
             );
         }
 
@@ -1227,6 +1229,9 @@ where
         Self::select_assign_extreme(tensor, dim, indices, value, |a, b| *b > *a)
     }
 
+    /// Shared traversal for the Min/Max select_assign variants. `replace` decides
+    /// whether the incoming value overwrites the destination; its comparison defines
+    /// the NaN handling.
     fn select_assign_extreme<I: NdArrayElement, F>(
         tensor: SharedArray<E>,
         dim: usize,
@@ -1237,6 +1242,32 @@ where
     where
         F: Fn(&mut E, &E) -> bool,
     {
+        let ndims = tensor.shape().num_dims();
+        assert!(
+            dim < ndims,
+            "select_assign_min/select_assign_max: dim {dim} is out of bounds for a {ndims}-D tensor"
+        );
+        assert_eq!(
+            indices.shape().num_dims(),
+            1,
+            "select_assign_min/select_assign_max: indices must be 1D, got shape {:?}",
+            indices.shape()
+        );
+        assert_eq!(
+            value.shape().num_dims(),
+            ndims,
+            "select_assign_min/select_assign_max: value rank ({}) must match tensor rank ({ndims})",
+            value.shape().num_dims()
+        );
+        assert_eq!(
+            value.shape()[dim],
+            indices.shape()[0],
+            "select_assign_min/select_assign_max: value dim {dim} ({}) must equal the number of \
+             indices ({})",
+            value.shape()[dim],
+            indices.shape()[0]
+        );
+
         let mut output_array = tensor.into_owned();
 
         for (index_value, index) in indices.into_iter().enumerate() {

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -293,6 +293,120 @@ where
         output
     }
 
+    pub fn scatter_min<I: NdArrayElement>(
+        dim: usize,
+        mut tensor: SharedArray<E>,
+        mut indices: SharedArray<I>,
+        mut value: SharedArray<E>,
+    ) -> SharedArray<E>
+    where
+        E: PartialOrd,
+    {
+        let ndims = tensor.shape().num_dims();
+        if dim != ndims - 1 {
+            tensor.swap_axes(ndims - 1, dim);
+            indices.swap_axes(ndims - 1, dim);
+            value.swap_axes(ndims - 1, dim);
+        }
+
+        let (shape_tensor, shape_indices, shape_value) =
+            (tensor.shape().into_shape(), indices.shape(), value.shape());
+        let (size_tensor, size_index, size_value) = (
+            shape_tensor[ndims - 1],
+            shape_indices[ndims - 1],
+            shape_value[ndims - 1],
+        );
+        let batch_size = Self::gather_batch_size(&shape_tensor, shape_indices);
+
+        if shape_value != shape_indices {
+            panic!(
+                "Invalid dimension: the shape of the index tensor should be the same as the value \
+                 tensor: Index {:?} value {:?}",
+                shape_indices, shape_value
+            );
+        }
+
+        let indices = NdArrayOps::reshape(indices, Shape::new([batch_size, size_index]));
+        let value = NdArrayOps::reshape(value, Shape::new([batch_size, size_value]));
+        let mut tensor = NdArrayOps::reshape(tensor, Shape::new([batch_size, size_tensor]));
+
+        for b in 0..batch_size {
+            let indices = indices.slice(s!(b, ..));
+
+            for (i, index) in indices.iter().enumerate() {
+                let index = index.elem::<i64>() as usize;
+                let value = value[[b, i]];
+                let out = &mut tensor[[b, index]];
+                if value < *out {
+                    *out = value;
+                }
+            }
+        }
+
+        let mut output = NdArrayOps::reshape(tensor.into_shared().into_dyn(), shape_tensor);
+        if dim != ndims - 1 {
+            output.swap_axes(ndims - 1, dim);
+        }
+        output
+    }
+
+    pub fn scatter_max<I: NdArrayElement>(
+        dim: usize,
+        mut tensor: SharedArray<E>,
+        mut indices: SharedArray<I>,
+        mut value: SharedArray<E>,
+    ) -> SharedArray<E>
+    where
+        E: PartialOrd,
+    {
+        let ndims = tensor.shape().num_dims();
+        if dim != ndims - 1 {
+            tensor.swap_axes(ndims - 1, dim);
+            indices.swap_axes(ndims - 1, dim);
+            value.swap_axes(ndims - 1, dim);
+        }
+
+        let (shape_tensor, shape_indices, shape_value) =
+            (tensor.shape().into_shape(), indices.shape(), value.shape());
+        let (size_tensor, size_index, size_value) = (
+            shape_tensor[ndims - 1],
+            shape_indices[ndims - 1],
+            shape_value[ndims - 1],
+        );
+        let batch_size = Self::gather_batch_size(&shape_tensor, shape_indices);
+
+        if shape_value != shape_indices {
+            panic!(
+                "Invalid dimension: the shape of the index tensor should be the same as the value \
+                 tensor: Index {:?} value {:?}",
+                shape_indices, shape_value
+            );
+        }
+
+        let indices = NdArrayOps::reshape(indices, Shape::new([batch_size, size_index]));
+        let value = NdArrayOps::reshape(value, Shape::new([batch_size, size_value]));
+        let mut tensor = NdArrayOps::reshape(tensor, Shape::new([batch_size, size_tensor]));
+
+        for b in 0..batch_size {
+            let indices = indices.slice(s!(b, ..));
+
+            for (i, index) in indices.iter().enumerate() {
+                let index = index.elem::<i64>() as usize;
+                let value = value[[b, i]];
+                let out = &mut tensor[[b, index]];
+                if value > *out {
+                    *out = value;
+                }
+            }
+        }
+
+        let mut output = NdArrayOps::reshape(tensor.into_shared().into_dyn(), shape_tensor);
+        if dim != ndims - 1 {
+            output.swap_axes(ndims - 1, dim);
+        }
+        output
+    }
+
     pub fn scatter_nd<I: NdArrayElement>(
         data: SharedArray<E>,
         indices: SharedArray<I>,
@@ -1116,6 +1230,56 @@ where
             let value = value.index_axis(Axis(dim), index_value);
 
             view.zip_mut_with(&value, |a, b| *a = *a * *b);
+        }
+
+        output_array.into_shared()
+    }
+
+    pub fn select_assign_min<I: NdArrayElement>(
+        tensor: SharedArray<E>,
+        dim: usize,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
+    ) -> SharedArray<E>
+    where
+        E: PartialOrd,
+    {
+        let mut output_array = tensor.into_owned();
+
+        for (index_value, index) in indices.into_iter().enumerate() {
+            let mut view = output_array.index_axis_mut(Axis(dim), index.elem::<i64>() as usize);
+            let value = value.index_axis(Axis(dim), index_value);
+
+            view.zip_mut_with(&value, |a, b| {
+                if *b < *a {
+                    *a = *b;
+                }
+            });
+        }
+
+        output_array.into_shared()
+    }
+
+    pub fn select_assign_max<I: NdArrayElement>(
+        tensor: SharedArray<E>,
+        dim: usize,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
+    ) -> SharedArray<E>
+    where
+        E: PartialOrd,
+    {
+        let mut output_array = tensor.into_owned();
+
+        for (index_value, index) in indices.into_iter().enumerate() {
+            let mut view = output_array.index_axis_mut(Axis(dim), index.elem::<i64>() as usize);
+            let value = value.index_axis(Axis(dim), index_value);
+
+            view.zip_mut_with(&value, |a, b| {
+                if *b > *a {
+                    *a = *b;
+                }
+            });
         }
 
         output_array.into_shared()

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -295,69 +295,37 @@ where
 
     pub fn scatter_min<I: NdArrayElement>(
         dim: usize,
-        mut tensor: SharedArray<E>,
-        mut indices: SharedArray<I>,
-        mut value: SharedArray<E>,
+        tensor: SharedArray<E>,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
     ) -> SharedArray<E>
     where
         E: PartialOrd,
     {
-        let ndims = tensor.shape().num_dims();
-        if dim != ndims - 1 {
-            tensor.swap_axes(ndims - 1, dim);
-            indices.swap_axes(ndims - 1, dim);
-            value.swap_axes(ndims - 1, dim);
-        }
-
-        let (shape_tensor, shape_indices, shape_value) =
-            (tensor.shape().into_shape(), indices.shape(), value.shape());
-        let (size_tensor, size_index, size_value) = (
-            shape_tensor[ndims - 1],
-            shape_indices[ndims - 1],
-            shape_value[ndims - 1],
-        );
-        let batch_size = Self::gather_batch_size(&shape_tensor, shape_indices);
-
-        if shape_value != shape_indices {
-            panic!(
-                "Invalid dimension: the shape of the index tensor should be the same as the value \
-                 tensor: Index {:?} value {:?}",
-                shape_indices, shape_value
-            );
-        }
-
-        let indices = NdArrayOps::reshape(indices, Shape::new([batch_size, size_index]));
-        let value = NdArrayOps::reshape(value, Shape::new([batch_size, size_value]));
-        let mut tensor = NdArrayOps::reshape(tensor, Shape::new([batch_size, size_tensor]));
-
-        for b in 0..batch_size {
-            let indices = indices.slice(s!(b, ..));
-
-            for (i, index) in indices.iter().enumerate() {
-                let index = index.elem::<i64>() as usize;
-                let value = value[[b, i]];
-                let out = &mut tensor[[b, index]];
-                if value < *out {
-                    *out = value;
-                }
-            }
-        }
-
-        let mut output = NdArrayOps::reshape(tensor.into_shared().into_dyn(), shape_tensor);
-        if dim != ndims - 1 {
-            output.swap_axes(ndims - 1, dim);
-        }
-        output
+        Self::scatter_extreme(dim, tensor, indices, value, |out, value| value < *out)
     }
 
     pub fn scatter_max<I: NdArrayElement>(
         dim: usize,
-        mut tensor: SharedArray<E>,
-        mut indices: SharedArray<I>,
-        mut value: SharedArray<E>,
+        tensor: SharedArray<E>,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
     ) -> SharedArray<E>
     where
         E: PartialOrd,
+    {
+        Self::scatter_extreme(dim, tensor, indices, value, |out, value| value > *out)
+    }
+
+    fn scatter_extreme<I: NdArrayElement, F>(
+        dim: usize,
+        mut tensor: SharedArray<E>,
+        mut indices: SharedArray<I>,
+        mut value: SharedArray<E>,
+        replace: F,
+    ) -> SharedArray<E>
+    where
+        F: Fn(&E, E) -> bool,
     {
         let ndims = tensor.shape().num_dims();
         if dim != ndims - 1 {
@@ -394,7 +362,7 @@ where
                 let index = index.elem::<i64>() as usize;
                 let value = value[[b, i]];
                 let out = &mut tensor[[b, index]];
-                if value > *out {
+                if replace(out, value) {
                     *out = value;
                 }
             }
@@ -1244,20 +1212,7 @@ where
     where
         E: PartialOrd,
     {
-        let mut output_array = tensor.into_owned();
-
-        for (index_value, index) in indices.into_iter().enumerate() {
-            let mut view = output_array.index_axis_mut(Axis(dim), index.elem::<i64>() as usize);
-            let value = value.index_axis(Axis(dim), index_value);
-
-            view.zip_mut_with(&value, |a, b| {
-                if *b < *a {
-                    *a = *b;
-                }
-            });
-        }
-
-        output_array.into_shared()
+        Self::select_assign_extreme(tensor, dim, indices, value, |a, b| *b < *a)
     }
 
     pub fn select_assign_max<I: NdArrayElement>(
@@ -1269,6 +1224,19 @@ where
     where
         E: PartialOrd,
     {
+        Self::select_assign_extreme(tensor, dim, indices, value, |a, b| *b > *a)
+    }
+
+    fn select_assign_extreme<I: NdArrayElement, F>(
+        tensor: SharedArray<E>,
+        dim: usize,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
+        replace: F,
+    ) -> SharedArray<E>
+    where
+        F: Fn(&mut E, &E) -> bool,
+    {
         let mut output_array = tensor.into_owned();
 
         for (index_value, index) in indices.into_iter().enumerate() {
@@ -1276,7 +1244,7 @@ where
             let value = value.index_axis(Axis(dim), index_value);
 
             view.zip_mut_with(&value, |a, b| {
-                if *b > *a {
+                if replace(a, b) {
                     *a = *b;
                 }
             });

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -295,7 +295,20 @@ impl IntTensorOps<Self> for NdArray {
                     ))
                 })
             }
-            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_min(
+                        dim, tensor, idx_array, value
+                    ))
+                })
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_max(
+                        dim, tensor, idx_array, value
+                    ))
+                })
+            }
         }
     }
 
@@ -355,7 +368,20 @@ impl IntTensorOps<Self> for NdArray {
                     })
                 })
             }
-            other => unimplemented!("int_select_assign with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| {
+                        NdArrayMathOps::<I>::select_assign_min(tensor, dim, idx_array, value)
+                    })
+                })
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| {
+                        NdArrayMathOps::<I>::select_assign_max(tensor, dim, idx_array, value)
+                    })
+                })
+            }
         }
     }
     fn int_argmax(tensor: NdArrayTensor, dim: usize) -> NdArrayTensor {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -220,7 +220,28 @@ impl FloatTensorOps<Self> for NdArray {
                     }
                 )
             }
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayOps::scatter_min(dim, tensor, idx_array, value)
+                        })
+                    }
+                )
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayOps::scatter_max(dim, tensor, idx_array, value)
+                        })
+                    }
+                )
+            }
         }
     }
 
@@ -310,8 +331,27 @@ impl FloatTensorOps<Self> for NdArray {
                     }
                 )
             }
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayMathOps::select_assign_min(tensor, dim, idx_array, value)
+                        })
+                    }
+                )
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayMathOps::select_assign_max(tensor, dim, idx_array, value)
+                        })
+                    }
+                )
             }
         }
     }

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -265,6 +265,42 @@ impl TchOps {
         TchTensor::from_existing(tensor, storage)
     }
 
+    pub fn scatter_min(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        let storage = tensor.storage.clone();
+        let tensor = tensor.tensor.internal_scatter_reduce(
+            dim as i64,
+            &indices.tensor,
+            &value.tensor,
+            "amin",
+            true,
+        );
+
+        TchTensor::from_existing(tensor, storage)
+    }
+
+    pub fn scatter_max(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        let storage = tensor.storage.clone();
+        let tensor = tensor.tensor.internal_scatter_reduce(
+            dim as i64,
+            &indices.tensor,
+            &value.tensor,
+            "amax",
+            true,
+        );
+
+        TchTensor::from_existing(tensor, storage)
+    }
+
     /// Flatten K-dimensional index tuples into 1D linear offsets, suitable for
     /// use with PyTorch's scatter/gather along dim 0 of a flattened tensor.
     ///
@@ -396,6 +432,34 @@ impl TchOps {
                 tensor.index_reduce_(dim as i64, &indices.tensor, &value.tensor, "prod", true)
             },
             |tensor| tensor.index_reduce(dim as i64, &indices.tensor, &value.tensor, "prod", true),
+        )
+    }
+
+    pub fn select_assign_min(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        tensor.clone().unary_ops(
+            |mut tensor| {
+                tensor.index_reduce_(dim as i64, &indices.tensor, &value.tensor, "amin", true)
+            },
+            |tensor| tensor.index_reduce(dim as i64, &indices.tensor, &value.tensor, "amin", true),
+        )
+    }
+
+    pub fn select_assign_max(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        tensor.clone().unary_ops(
+            |mut tensor| {
+                tensor.index_reduce_(dim as i64, &indices.tensor, &value.tensor, "amax", true)
+            },
+            |tensor| tensor.index_reduce(dim as i64, &indices.tensor, &value.tensor, "amax", true),
         )
     }
 

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -300,7 +300,12 @@ impl IntTensorOps<Self> for LibTorch {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 TchOps::scatter_mul(dim, tensor, indices, value)
             }
-            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                TchOps::scatter_min(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                TchOps::scatter_max(dim, tensor, indices, value)
+            }
         }
     }
 
@@ -338,8 +343,11 @@ impl IntTensorOps<Self> for LibTorch {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 TchOps::select_assign_mul(tensor, dim, indices, value)
             }
-            other => {
-                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                TchOps::select_assign_min(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                TchOps::select_assign_max(tensor, dim, indices, value)
             }
         }
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -211,7 +211,12 @@ impl FloatTensorOps<Self> for LibTorch {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 TchOps::scatter_mul(dim, tensor, indices, value)
             }
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                TchOps::scatter_min(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                TchOps::scatter_max(dim, tensor, indices, value)
+            }
         }
     }
 
@@ -249,8 +254,11 @@ impl FloatTensorOps<Self> for LibTorch {
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 TchOps::select_assign_mul(tensor, dim, indices, value)
             }
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            burn_backend::tensor::IndexingUpdateOp::Min => {
+                TchOps::select_assign_min(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Max => {
+                TchOps::select_assign_max(tensor, dim, indices, value)
             }
         }
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1655,6 +1655,8 @@ where
     ///   and the backward gradients.
     /// - For `Mul`, duplicate indices are multiplied in an unspecified order and backward
     ///   gradients are undefined.
+    /// - For `Min` and `Max`, duplicate indices are reduced to the minimum/maximum over all
+    ///   contributions, but the backward gradients are undefined.
     ///
     /// For deterministic results and correct gradient calculation across all operations,
     /// `indices` should contain unique entries.
@@ -1899,6 +1901,8 @@ where
     ///   and the backward gradients.
     /// - For `Mul`, duplicate indices are multiplied in an unspecified order and backward
     ///   gradients are undefined.
+    /// - For `Min` and `Max`, duplicate indices are reduced to the minimum/maximum over all
+    ///   contributions, but the backward gradients are undefined.
     ///
     /// For deterministic results and correct gradient calculation across all operations,
     /// `indices` should contain unique entries.


### PR DESCRIPTION
Resolves the remaining gap in #5522: element-wise `scatter` / `select_assign` only supported `Assign`, `Add` and `Mul`, and every backend hit `unimplemented!` for `Min` / `Max` — even though `scatter_nd` already implements all five variants.

### Changes

- **ndarray**: add `scatter_min` / `scatter_max` and `select_assign_min` / `select_assign_max` primitives (per-element compare, same shape/index handling as the existing `_mul` variants).
- **flex**: `scatter_min` / `scatter_max` and `select_min` / `select_max` helpers sharing the existing `scatter_update` / `select_update` walkers.
- **cubecl**: new `scatter_min` / `scatter_max` and `select_assign_min` / `select_assign_max` entries reusing the existing `BinaryMinOp` / `BinaryMaxOp` kernels (already wired for `scatter_nd`).
- **tch**: `scatter_min` / `scatter_max` via `scatter_reduce(..., "amin"/"amax")` and `select_assign_min` / `select_assign_max` via `index_reduce_(..., "amin"/"amax")`, mirroring the existing `"prod"` paths.
- **autodiff**: backward passes for `Min` / `Max` scatter and select_assign, mirroring the `scatter_nd` Min/Max gradient (winner masks from comparisons, ties contribute to both inputs per the cummin/cummax convention; unique indices required, as with `scatter_nd`).
- Dispatch matches in all backends now enumerate every `IndexingUpdateOp` variant, so an unsupported combination fails at compile time instead of panicking at runtime.

### Tests

- Forward: float and int `scatter` / `select_assign` with `Min` / `Max`, 1D and 2D, in `burn-backend-tests/tests/tensor/{float,int}/ops/`.
- Autodiff: data-win and values-win gradient cases for `Min` / `Max` `scatter` and `select_assign`.

### Verification

- `cargo test -p burn-backend-tests --features ndarray`: 1839 tensor + 572 autodiff tests pass.
- Confirmed the autodiff tests fail with the previous `unimplemented!` when the Min/Max backward is removed.
- `cargo clippy` clean for `burn-ndarray`, `burn-flex`, `burn-autodiff`, `burn-cubecl`.

Note: `burn-tch` compiles against libtorch, which is unavailable in my local environment; the changes are a direct mirror of the existing `"prod"` scatter/`index_reduce` paths that already use `"amin"/"amax"` in `scatter_nd`.