### PR TITLE
chore: update cubek rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1746,7 +1746,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2591,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
 ]
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=e7a3ffceaad86a9fab6cebff0ab977a42ae0924d#e7a3ffceaad86a9fab6cebff0ab977a42ae0924d"
+source = "git+https://github.com/tracel-ai/cubek?rev=6d1b97fe68233ad53a9ae03dc9594d4d60128d9a#6d1b97fe68233ad53a9ae03dc9594d4d60128d9a"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3187,7 +3187,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3543,7 +3543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4040,8 +4040,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.20",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4342,10 +4342,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4684,7 +4680,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6391,7 +6387,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7184,7 +7180,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.14.5",
+ "hashbrown 0.13.2",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7197,7 +7193,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.12.3",
+ "spin 0.10.1",
  "thiserror 2.0.20",
  "utf8-chars",
 ]
@@ -8196,7 +8192,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8931,7 +8927,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8989,7 +8985,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9512,7 +9508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9548,6 +9544,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -9640,7 +9639,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9907,7 +9906,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9929,7 +9928,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9939,7 +9938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11408,7 +11407,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11884,8 +11883,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.20",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "12031580a031b1b3fa8b80c216e085f3e42177af" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "12031580a031b1b3fa8b80c216e085f3e42177af" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "12031580a031b1b3fa8b80c216e085f3e42177af" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e7a3ffceaad86a9fab6cebff0ab977a42ae0924d" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "6d1b97fe68233ad53a9ae03dc9594d4d60128d9a" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
Bumps `cubek` to `6d1b97fe68233ad53a9ae03dc9594d4d60128d9a`.

Supersedes #5588, whose branch was 51 commits behind `main` and pointed at cubecl/cubek revs already superseded by #5586 and #5587.