### PR TITLE
fix(nn): honor count_include_pad for asymmetric average pooling

### DIFF
--- a/crates/burn-nn/src/modules/pool/avg_pool1d.rs
+++ b/crates/burn-nn/src/modules/pool/avg_pool1d.rs
@@ -110,18 +110,45 @@ impl AvgPool1d {
         // See: https://github.com/tracel-ai/burn/issues/4362
         // Handle asymmetric padding by applying explicit pad operation first
         if left != right {
+            let valid = if self.count_include_pad {
+                None
+            } else {
+                let device = input.device();
+                Some(
+                    Tensor::<3>::ones([1, 1, length], (&device, input.dtype()))
+                        .pad((left, right, 0, 0), PadMode::Constant(0.0)),
+                )
+            };
             // Burn's pad takes (left, right, top, bottom) for the last two dimensions
             // For 1D (NCL format), we only pad L (last dim), so top/bottom = 0
             let padded = input.pad((left, right, 0, 0), PadMode::Constant(0.0));
             // Use zero padding for the pool operation since we already padded
-            avg_pool1d(
+            let output = avg_pool1d(
                 padded,
                 self.kernel_size,
                 self.stride,
                 0,
                 self.count_include_pad,
                 self.ceil_mode,
-            )
+            );
+
+            if let Some(valid) = valid {
+                // Materialized padding is indistinguishable from input to the backend. Pooling a
+                // validity mask with the same settings recovers the fraction of real values in
+                // each window, including partial windows created by ceil mode.
+                let valid = avg_pool1d(
+                    valid,
+                    self.kernel_size,
+                    self.stride,
+                    0,
+                    false,
+                    self.ceil_mode,
+                );
+                let empty = valid.clone().equal_elem(0.0);
+                output / valid.mask_fill(empty, 1.0)
+            } else {
+                output
+            }
         } else {
             // Symmetric padding
             avg_pool1d(
@@ -139,6 +166,7 @@ impl AvgPool1d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use burn::tensor::{Device, TensorData, Tolerance};
     use rstest::rstest;
 
     #[test]
@@ -197,6 +225,92 @@ mod tests {
         // With asymmetric padding (1, 2), input length 4 becomes 4+1+2=7
         // Output length = (7 - 3) / 1 + 1 = 5
         assert_eq!(output.dims(), [1, 2, 5]);
+    }
+
+    #[test]
+    fn asymmetric_padding_mask_broadcasts_without_excluding_input_zeros() {
+        let device = Default::default();
+        let input = Tensor::from_data(
+            [
+                [[0.0f32, 2.0, 4.0], [2.0, 0.0, 6.0]],
+                [[0.0, 0.0, 8.0], [-2.0, 2.0, 0.0]],
+            ],
+            &device,
+        );
+        let pool = AvgPool1dConfig::new(2)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Explicit(0, 1))
+            .with_count_include_pad(false)
+            .init();
+
+        let output = pool.forward(input);
+
+        output.to_data().assert_eq(
+            &TensorData::from([[[1.0f32, 4.0], [1.0, 6.0]], [[0.0, 8.0], [0.0, 0.0]]]),
+            true,
+        );
+    }
+
+    #[test]
+    fn same_asymmetric_padding_excludes_pad_from_average() {
+        let device = Default::default();
+        let input = Tensor::from_data([[[1.0f32, 2.0, 3.0, 4.0, 5.0]]], &device);
+        let pool = AvgPool1dConfig::new(2)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Same)
+            .with_count_include_pad(false)
+            .init();
+
+        let output = pool.forward(input);
+
+        output
+            .to_data()
+            .assert_eq(&TensorData::from([[[1.5f32, 3.5, 5.0]]]), true);
+    }
+
+    #[test]
+    fn asymmetric_padding_still_counts_pad_when_enabled() {
+        let device = Default::default();
+        let input = Tensor::from_data([[[1.0f32, 2.0, 3.0, 4.0, 5.0]]], &device);
+        let pool = AvgPool1dConfig::new(2)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Explicit(0, 1))
+            .with_count_include_pad(true)
+            .init();
+
+        let output = pool.forward(input);
+
+        output
+            .to_data()
+            .assert_eq(&TensorData::from([[[1.5f32, 3.5, 2.5]]]), true);
+    }
+
+    #[test]
+    fn ceil_mode_excludes_asymmetric_pad_and_preserves_gradients() {
+        let device = Device::default().autodiff();
+        let input = Tensor::from_data([[[2.0f32, 4.0, 6.0, 8.0]]], &device).require_grad();
+        let pool = AvgPool1dConfig::new(2)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Explicit(1, 0))
+            .with_count_include_pad(false)
+            .with_ceil_mode(true)
+            .init();
+
+        let output = pool.forward(input.clone());
+        output
+            .clone()
+            .to_data()
+            .assert_eq(&TensorData::from([[[2.0f32, 5.0, 8.0]]]), true);
+
+        let gradients = output.sum().backward();
+        input
+            .grad(&gradients)
+            .unwrap()
+            .to_data()
+            .assert_approx_eq::<f32>(
+                &TensorData::from([[[1.0f32, 0.5, 0.5, 1.0]]]),
+                Tolerance::default(),
+            );
     }
 
     #[test]

--- a/crates/burn-nn/src/modules/pool/avg_pool2d.rs
+++ b/crates/burn-nn/src/modules/pool/avg_pool2d.rs
@@ -113,17 +113,44 @@ impl AvgPool2d {
         // See: https://github.com/tracel-ai/burn/issues/4362
         // Handle asymmetric padding by applying explicit pad operation first
         if top != bottom || left != right {
+            let valid = if self.count_include_pad {
+                None
+            } else {
+                let device = input.device();
+                Some(
+                    Tensor::<4>::ones([1, 1, height_in, width_in], (&device, input.dtype()))
+                        .pad((left, right, top, bottom), PadMode::Constant(0.0)),
+                )
+            };
             // Burn's pad takes (left, right, top, bottom) for the last two dimensions
             let padded = input.pad((left, right, top, bottom), PadMode::Constant(0.0));
             // Use zero padding for the pool operation since we already padded
-            avg_pool2d(
+            let output = avg_pool2d(
                 padded,
                 self.kernel_size,
                 self.stride,
                 [0, 0],
                 self.count_include_pad,
                 self.ceil_mode,
-            )
+            );
+
+            if let Some(valid) = valid {
+                // Materialized padding is indistinguishable from input to the backend. Pooling a
+                // validity mask with the same settings recovers the fraction of real values in
+                // each window, including partial windows created by ceil mode.
+                let valid = avg_pool2d(
+                    valid,
+                    self.kernel_size,
+                    self.stride,
+                    [0, 0],
+                    false,
+                    self.ceil_mode,
+                );
+                let empty = valid.clone().equal_elem(0.0);
+                output / valid.mask_fill(empty, 1.0)
+            } else {
+                output
+            }
         } else {
             // Symmetric padding
             avg_pool2d(
@@ -141,6 +168,7 @@ impl AvgPool2d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use burn::tensor::{Device, TensorData, Tolerance};
     use rstest::rstest;
 
     #[test]
@@ -200,6 +228,83 @@ mod tests {
         // Height: 4 + 1 + 3 = 8, output = (8 - 3) / 1 + 1 = 6
         // Width: 5 + 2 + 4 = 11, output = (11 - 3) / 1 + 1 = 9
         assert_eq!(output.dims(), [1, 2, 6, 9]);
+    }
+
+    #[test]
+    fn asymmetric_padding_excludes_pad_from_average() {
+        let device = Default::default();
+        let input = Tensor::<1>::from_data(
+            [
+                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0,
+            ],
+            &device,
+        )
+        .reshape([1, 1, 5, 5]);
+        let pool = AvgPool2dConfig::new([2, 2])
+            .with_strides([2, 2])
+            .with_padding(PaddingConfig2d::Explicit(0, 0, 1, 1))
+            .with_count_include_pad(false)
+            .init();
+
+        let output = pool.forward(input);
+        let expected =
+            TensorData::from([[[[4.0f32, 6.0, 7.5], [14.0, 16.0, 17.5], [21.5, 23.5, 25.0]]]]);
+
+        output.to_data().assert_eq(&expected, true);
+    }
+
+    #[test]
+    fn fully_padded_windows_are_finite_and_count_flag_is_preserved() {
+        let device = Default::default();
+        let input = Tensor::from_data([[[[4.0f32]]]], &device);
+
+        let include_pad = AvgPool2dConfig::new([2, 2])
+            .with_strides([1, 1])
+            .with_padding(PaddingConfig2d::Explicit(2, 0, 0, 1))
+            .with_count_include_pad(true)
+            .init()
+            .forward(input.clone());
+        include_pad
+            .to_data()
+            .assert_eq(&TensorData::from([[[[0.0f32], [1.0]]]]), true);
+
+        let exclude_pad = AvgPool2dConfig::new([2, 2])
+            .with_strides([1, 1])
+            .with_padding(PaddingConfig2d::Explicit(2, 0, 0, 1))
+            .with_count_include_pad(false)
+            .init()
+            .forward(input);
+        exclude_pad
+            .to_data()
+            .assert_eq(&TensorData::from([[[[0.0f32], [4.0]]]]), true);
+    }
+
+    #[test]
+    fn asymmetric_padding_excludes_pad_from_gradients() {
+        let device = Device::default().autodiff();
+        let input = Tensor::ones([1, 1, 5, 5], &device).require_grad();
+        let pool = AvgPool2dConfig::new([2, 2])
+            .with_strides([2, 2])
+            .with_padding(PaddingConfig2d::Explicit(0, 0, 1, 1))
+            .with_count_include_pad(false)
+            .init();
+
+        let output = pool.forward(input.clone());
+        let gradients = output.sum().backward();
+        let expected = TensorData::from([[[
+            [0.25f32, 0.25, 0.25, 0.25, 0.5],
+            [0.25, 0.25, 0.25, 0.25, 0.5],
+            [0.25, 0.25, 0.25, 0.25, 0.5],
+            [0.25, 0.25, 0.25, 0.25, 0.5],
+            [0.5, 0.5, 0.5, 0.5, 1.0],
+        ]]]);
+
+        input
+            .grad(&gradients)
+            .unwrap()
+            .to_data()
+            .assert_approx_eq::<f32>(&expected, Tolerance::default());
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Closes #5450.

The broader pooling API refactor tracked by #4362 remains out of scope.

### Changes

`AvgPool1d` and `AvgPool2d` materialize asymmetric padding before invoking the backend pool operation. At that point the synthetic zeros are ordinary tensor elements, so the backend can no longer exclude them from the divisor when `count_include_pad=false`. Edge values were therefore too small even though output shapes were correct.

For the asymmetric exclude-pad path, this change pools a singleton validity mask with the same kernel, stride, and ceil-mode settings, then divides the pooled input by the resulting valid-element fraction. The mask contains ones for every real input position—including legitimate zero-valued inputs—and zeros only for materialized padding. Its singleton batch/channel dimensions broadcast over the input, and its dtype and device match the input. A zero validity fraction is replaced with one before division so a fully padded window remains finite at zero.

Symmetric padding and `count_include_pad=true` continue through their existing paths. The change stays within `burn-nn`; it adds no dependency or backend/API change. The asymmetric exclude-pad path now performs one additional mask pooling operation.

No book update is needed because the public API and documented configuration semantics are unchanged; this corrects the implementation of the existing `count_include_pad` behavior. The diff contains only the two pooling modules and their inline regressions.

AI tools assisted with implementation and review. In line with Burn's change-ownership policy, responsibility for understanding, explaining, and maintaining the change remains with the PR author.

### Testing

Tested commit: `112e6733df92acfaac9ddbc53154674d19b13d7b`.

#### Red evidence

The regressions were exercised before applying the validity-mask correction:

- `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex asymmetric_padding_excludes -- --nocapture` exited 101 with 0 passed and 4 failed. The 1D explicit and odd-`Same` cases each produced `2.5 != 5` at position 2; the 2D explicit case included `3.75 != 7.5`, `8.75 != 17.5`, `10.75 != 21.5`, `11.75 != 23.5`, and `6.25 != 25`; the 2D gradient case produced `0.25 != 0.5` at padded edges.
- `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex ceil_mode_excludes -- --nocapture` exited 101 with `1 != 2` at position 0.
- `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex fully_padded_windows -- --nocapture` exited 101 with `1 != 4` at position 1.
- With validity normalization temporarily disabled, `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex asymmetric_padding_mask_broadcasts_without_excluding_input_zeros -- --nocapture` exited 101 with `2 != 4`, `3 != 6`, and `4 != 8` at positions 1, 3, and 5. This final regression covers two batches, two channels, genuine input zeros, and cancelling nonzero values.
- The `count_include_pad=true` control passed before the fix: 1 passed, 0 failed.

#### Green evidence

- `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex avg_pool` — exit 0; 23 passed, 0 failed.
- `BURN_DEVICE=flex cargo +1.96.1 test -p burn-nn --features burn-core/flex` — exit 0; 514 unit tests and 6 integration tests passed with 0 failures; doctest runs completed successfully.
- `cargo +1.96.1 run-checks` — exit 0 on the tested commit. Formatting, typo scanning, dependency audit, workspace Clippy with warnings denied, no-std checks, and release Flex backend tests completed successfully.
- Independent exact-SHA verification also passed `git diff --check HEAD^ HEAD`, `cargo +1.96.1 fmt --all -- --check`, and the 23-test focused average-pooling command above.

Rust 1.96.1 was used because the installed default Rust 1.93.0 cannot build the current dependency set: `cubecl-zspace 0.11.0-pre.3` and `hi_sparse_bitset 0.9.0` require Rust 1.95 or newer.

Validation used Flex on the host CPU. No GPU hardware/runtime backend matrix was run, and the new pooling regressions were not parameterized across the full supported dtype matrix.
