### PR TITLE
fix(autodiff): scope orphan cleanup to active graph

### DIFF
--- a/crates/burn-autodiff/src/runtime/graph.rs
+++ b/crates/burn-autodiff/src/runtime/graph.rs
@@ -119,7 +119,7 @@ impl AutodiffClient for GraphMutexClient {
                 .backward::<GraphCleaner, B>(root.node, root.primitive, node_id, mode)
         }; // lock released
 
-        GraphCleaner::cleanup_orphaned_entries();
+        GraphCleaner::cleanup_orphaned_entries(&graph);
 
         grads
     }
@@ -130,36 +130,21 @@ struct GraphCleaner<'a> {
 }
 
 impl<'a> GraphCleaner<'a> {
-    fn cleanup_orphaned_entries() {
-        let graphs = {
-            // Get the available graphs and release the lock
-            match STATE.lock().as_ref() {
-                Some(state) => state.graphs.clone(),
-                None => return,
-            }
-        };
-
+    fn cleanup_orphaned_entries(graph: &Arc<Graph>) {
         let mut should_remove = Vec::new();
-        for graph in graphs.values() {
-            {
-                // Best-effort sweep: a graph whose mutex is contended is in
-                // use — possibly by this very thread, when a `Backward` step
-                // itself runs an inner `backward()` (the outer backward holds
-                // its graph's lock across step execution, and this mutex is
-                // not reentrant). Skip it; a later backward's sweep will
-                // collect its orphans.
-                let Some(mut guard) = graph.state.try_lock() else {
-                    continue;
-                };
-                // Double safety: in case it was marked as no longer useful, but other
-                // nodes are still relevant, we only check which nodes can safely be removed.
-                if !guard.server.maybe_useful() {
-                    guard
-                        .server
-                        .free_unused_roots(|node| should_remove.push(*node));
-                }
-            }
+        // The graph was just used by this backward pass. Other graphs may be
+        // concurrently building a step whose node is not referenced yet.
+        let Some(mut guard) = graph.state.try_lock() else {
+            #[cfg(feature = "tracing")]
+            tracing::trace!("Skipping autodiff orphan cleanup for a contended graph");
+            return;
+        };
+        if !guard.server.maybe_useful() {
+            guard
+                .server
+                .free_unused_roots(|node| should_remove.push(*node));
         }
+        drop(guard);
 
         if !should_remove.is_empty() {
             let mut state = STATE.lock();

--- a/crates/burn-backend-tests/tests/autodiff/multithread.rs
+++ b/crates/burn-backend-tests/tests/autodiff/multithread.rs
@@ -1,5 +1,6 @@
 use super::*;
-use burn_tensor::{TensorData, Tolerance};
+use burn_tensor::{Distribution, TensorData, Tolerance};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[test]
 // TODO: FIXME https://github.com/tracel-ai/burn/issues/4739
@@ -87,4 +88,59 @@ fn should_behave_the_same_with_multithread() {
     grad_2
         .into_data()
         .assert_approx_eq::<FloatElem>(&grad_2_moved.into_data(), Tolerance::default());
+}
+
+#[test]
+fn concurrent_backward_does_not_drop_reused_leaf_gradient() {
+    const ROUNDS: usize = 300;
+    const VICTIM_THREADS: usize = 6;
+    const SWEEPER_THREADS: usize = 6;
+
+    fn leaf(device: &burn_tensor::Device) -> TestTensor<2> {
+        TestTensor::<2>::random([256, 256], Distribution::Normal(0.0, 0.5), device).require_grad()
+    }
+
+    fn round(device: &burn_tensor::Device) -> bool {
+        let a = leaf(device);
+        let b = leaf(device);
+        let _ = a.clone().sum().backward();
+
+        let head = a.clone().tanh();
+        let output = TestTensor::cat(vec![head, b.clone().tanh()], 0);
+        let grads = output.sum().backward();
+
+        a.grad(&grads).is_some() && b.grad(&grads).is_some()
+    }
+
+    fn sweep(stop: &AtomicBool, device: &burn_tensor::Device) {
+        while !stop.load(Ordering::Relaxed) {
+            let _ = leaf(device).tanh().sum().backward();
+        }
+    }
+
+    let device = AutodiffDevice::new();
+    let stop = AtomicBool::new(false);
+    let failures = std::thread::scope(|scope| {
+        for _ in 0..SWEEPER_THREADS {
+            let stop = &stop;
+            let device = device.clone();
+            scope.spawn(move || sweep(stop, &device));
+        }
+
+        let handles = (0..VICTIM_THREADS)
+            .map(|_| {
+                let device = device.clone();
+                scope.spawn(move || (0..ROUNDS).filter(|_| !round(&device)).count())
+            })
+            .collect::<Vec<_>>();
+
+        let failures: usize = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .sum();
+        stop.store(true, Ordering::Relaxed);
+        failures
+    });
+
+    assert_eq!(failures, 0, "{failures} rounds lost a gradient");
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Fixes #5573

### Changes

Concurrent backward passes could reclaim a step from another graph before that graph finished registering its child operation. This scopes orphan cleanup to the active graph and prevents the missing-gradient race.

### Testing

Added a multithreaded regression covering reused leaves and concurrent `backward()` calls; the normal and checkpointing variants pass, along with formatting, `git diff --check`, targeted memory-management tests, and `burn-autodiff` Clippy.