### PR TITLE
test(ndarray): preserve explicit dtype after default initialization

### DIFF
--- a/crates/burn-ndarray/src/backend.rs
+++ b/crates/burn-ndarray/src/backend.rs
@@ -209,6 +209,22 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn explicit_dtype_is_preserved_after_default_dtype_is_locked() {
+        use burn_backend::TensorMetadata;
+        use burn_backend::ops::FloatTensorOps;
+        use burn_std::TensorData;
+
+        type B = NdArray;
+        let device = NdArrayDevice::Cpu;
+
+        let default = burn_backend::get_device_settings::<B>(&device);
+        assert_eq!(default.float_dtype, burn_std::FloatDType::F32);
+        let explicit = B::float_from_data(TensorData::from([1.0f64]), &device);
+
+        assert_eq!(explicit.dtype(), DType::F64);
+    }
+
     /// A scheme this claims and then panics on is worse than one it declines, because the panic
     /// lands on the first tensor rather than where the scheme was chosen.
     #[test]


### PR DESCRIPTION
## Summary

Add focused coverage for the current NdArray dtype contract related to #5192. After the device F32 default is initialized, explicitly typed F64 data remains F64; the historical generic `NdArray<f32>`/`NdArray<f64>` reproduction is no longer applicable on `main` after #5000, so this does not claim to fix the `release/0.21` behavior.

## Testing

- `RUSTUP_TOOLCHAIN=1.96.1 RUSTC=/home/cc/.rustup/toolchains/1.96.1-x86_64-unknown-linux-gnu/bin/rustc RUSTDOC=/home/cc/.rustup/toolchains/1.96.1-x86_64-unknown-linux-gnu/bin/rustdoc cargo test -p burn-ndarray`
- `RUSTUP_TOOLCHAIN=1.96.1 RUSTC=/home/cc/.rustup/toolchains/1.96.1-x86_64-unknown-linux-gnu/bin/rustc RUSTDOC=/home/cc/.rustup/toolchains/1.96.1-x86_64-unknown-linux-gnu/bin/rustdoc cargo clippy -p burn-ndarray --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Reviewers

- Guillaume Lagrange
- Nathaniel Simard
- Roberto Meroni