### PR TITLE
test(backend): cover empty-axis autodiff reductions

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/aggregation.rs
+++ b/crates/burn-backend-tests/tests/autodiff/aggregation.rs
@@ -138,6 +138,24 @@ fn should_diff_sum_dim() {
 }
 
 #[test]
+fn should_diff_sum_dim_empty_axis() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::empty([3, 0], &device).require_grad();
+
+    let output = tensor.clone().sum_dim(1);
+    output
+        .to_data()
+        .assert_eq(&TensorData::from([[0.0], [0.0], [0.0]]), false);
+
+    let grads = output.sum().backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    assert_eq!(grad.shape().dims(), [3, 0]);
+    grad.to_data()
+        .assert_eq(&TensorData::new(Vec::<FloatElem>::new(), [3, 0]), false);
+}
+
+#[test]
 fn should_diff_prod() {
     let device = AutodiffDevice::new();
     let tensor =


### PR DESCRIPTION
## Changes

Add autodiff coverage for reducing a tensor with shape `[3, 0]` over its empty axis. The test verifies that each surviving output position receives the sum identity and that backward propagation preserves the empty input shape.

This covers both the base and gradient-checkpointing autodiff variants and contributes regression coverage for #5310.

## Testing

- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features wgpu,std --test autodiff -- test_mask_select_grad_empty_mask`
- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features wgpu,std --test autodiff -- should_diff_sum_dim_empty_axis`
- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features wgpu,std --test autodiff -- aggregation`
- `cargo +1.96.1 fmt --all -- --check`