### PR TITLE
perf(flex): write slice_assign in place when the destination is uniquely owned

### DIFF
--- a/crates/burn-flex/src/ops/slice.rs
+++ b/crates/burn-flex/src/ops/slice.rs
@@ -233,7 +233,19 @@ fn slice_write_impl<E: Element + bytemuck::Pod>(
     slices: &[Slice],
     source: WriteSource<'_, E>,
 ) -> FlexTensor {
-    let mut tensor = tensor.into_contiguous();
+    // A uniquely-owned contiguous prefix view needs no copy: every write
+    // below is computed from `dst_layout`, whose canonical strides and zero
+    // start offset keep it inside the logical prefix even when the buffer is
+    // longer. `into_contiguous` additionally demands a right-sized buffer
+    // (#4855) for callers that read `storage()` by length; this one doesn't.
+    let mut tensor = if tensor.is_unique()
+        && tensor.layout().is_contiguous()
+        && tensor.layout().start_offset() == 0
+    {
+        tensor
+    } else {
+        tensor.into_contiguous()
+    };
     let dst_layout = tensor.layout().clone();
     let ndims = dst_layout.num_dims();
 
@@ -730,5 +742,112 @@ mod tests {
         );
         assert_eq!(result.storage::<f32>()[..2], [1.0, 2.0]);
         assert_eq!(alias.storage::<f32>(), [0.0f32; 8]);
+    }
+
+    /// A uniquely-owned *prefix view* (`narrow` with the parent dropped) is
+    /// contiguous with offset 0, so every write `slice_write_impl` computes
+    /// from `dst_layout` lands inside the logical prefix. Writing it in place
+    /// is safe even though the buffer is longer than the tensor.
+    #[test]
+    fn test_slice_assign_unique_prefix_view_writes_in_place() {
+        let store = FlexTensor::from_data(TensorData::new(
+            (0..40).map(|i| i as f32).collect::<Vec<_>>(),
+            [8, 5],
+        ));
+        let view = store.narrow(0, 0, 5);
+        drop(store);
+        assert!(view.is_unique());
+        assert_eq!(view.storage::<f32>().len(), 40, "buffer outlives the view");
+        let buffer_before = view.bytes().as_ptr() as usize;
+
+        let value = FlexTensor::from_data(TensorData::new(vec![9.0f32; 5], [1, 5]));
+        let result = slice_assign(view, &[Slice::new(0, Some(1), 1)], value);
+
+        assert_eq!(
+            result.bytes().as_ptr() as usize,
+            buffer_before,
+            "slice_assign copied a uniquely-owned prefix view instead of writing in place"
+        );
+        let storage = result.storage::<f32>();
+        assert_eq!(storage[..5], [9.0; 5]);
+        // Everything after the assigned row is untouched, both inside the
+        // logical prefix and past its end.
+        assert_eq!(
+            storage[5..],
+            (5..40).map(|i| i as f32).collect::<Vec<_>>()[..]
+        );
+    }
+
+    /// A *shared* prefix view must still be compacted rather than written
+    /// through. Skipping the copy here would hand the whole-buffer copy to
+    /// `Arc::make_mut`, which duplicates the parent's full buffer instead of
+    /// just the view, and leaves the result oversized for every later write.
+    #[test]
+    fn test_slice_assign_shared_prefix_view_compacts() {
+        let store = FlexTensor::from_data(TensorData::new(
+            (0..40).map(|i| i as f32).collect::<Vec<_>>(),
+            [8, 5],
+        ));
+        let view = store.narrow(0, 0, 5);
+        assert!(!view.is_unique());
+
+        let value = FlexTensor::from_data(TensorData::new(vec![9.0f32; 5], [1, 5]));
+        let result = slice_assign(view, &[Slice::new(0, Some(1), 1)], value);
+
+        assert_eq!(
+            result.storage::<f32>().len(),
+            25,
+            "shared prefix view should be compacted to its logical size, not copied whole"
+        );
+        assert_eq!(result.storage::<f32>()[..5], [9.0; 5]);
+        assert_eq!(
+            store.storage::<f32>()[0],
+            0.0,
+            "COW did not protect the parent"
+        );
+    }
+
+    /// The other two conjuncts of that fast path are load-bearing, and no
+    /// existing test pins them: the 1-D and 2-D branches below compute
+    /// destination indices from canonical strides with no `start_offset`
+    /// term, so a unique destination that is merely offset, or merely
+    /// non-canonical, still has to go through `into_contiguous` first.
+    #[test]
+    fn test_slice_assign_unique_non_prefix_destinations_are_normalized() {
+        let base = || {
+            FlexTensor::from_data(TensorData::new(
+                (0..40).map(|i| i as f32).collect::<Vec<_>>(),
+                [8, 5],
+            ))
+        };
+
+        // Canonical strides, but start_offset 5.
+        let store = base();
+        let offset_view = store.narrow(0, 1, 5);
+        drop(store);
+        assert!(offset_view.is_unique() && offset_view.is_contiguous());
+        assert_eq!(offset_view.layout().start_offset(), 5);
+
+        let value = FlexTensor::from_data(TensorData::new(vec![9.0f32; 5], [1, 5]));
+        let result = slice_assign(offset_view, &[Slice::new(0, Some(1), 1)], value);
+        assert_eq!(
+            result.storage::<f32>()[..10],
+            [9.0, 9.0, 9.0, 9.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0]
+        );
+
+        // start_offset 0, but non-canonical strides.
+        let transposed = base().transpose(0, 1);
+        assert!(transposed.is_unique() && !transposed.is_contiguous());
+        assert_eq!(transposed.layout().start_offset(), 0);
+
+        let value = FlexTensor::from_data(TensorData::new(vec![9.0f32; 8], [1, 8]));
+        let result = slice_assign(transposed, &[Slice::new(0, Some(1), 1)], value);
+        assert_eq!(
+            result.storage::<f32>()[..16],
+            [
+                9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 9.0, 1.0, 6.0, 11.0, 16.0, 21.0, 26.0, 31.0,
+                36.0
+            ]
+        );
     }
 }

--- a/crates/burn-flex/src/ops/slice.rs
+++ b/crates/burn-flex/src/ops/slice.rs
@@ -233,7 +233,7 @@ fn slice_write_impl<E: Element + bytemuck::Pod>(
     slices: &[Slice],
     source: WriteSource<'_, E>,
 ) -> FlexTensor {
-    let mut tensor = tensor.to_contiguous();
+    let mut tensor = tensor.into_contiguous();
     let dst_layout = tensor.layout().clone();
     let ndims = dst_layout.num_dims();
 
@@ -686,5 +686,49 @@ mod tests {
             }
         }
         assert_eq!(values, expected);
+    }
+
+    /// Regression for #5575: `slice_assign` into a uniquely-owned
+    /// destination must write in place rather than copy the whole tensor.
+    #[test]
+    fn test_slice_assign_unique_destination_writes_in_place() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![0.0f32; 8], [8]));
+        assert!(tensor.is_unique());
+        // Addresses, not pointers: on the unfixed code the original buffer is
+        // freed by the time we compare.
+        let buffer_before = tensor.bytes().as_ptr() as usize;
+
+        let value = FlexTensor::from_data(TensorData::new(vec![1.0f32, 2.0], [2]));
+        let result = slice_assign(tensor, &[Slice::new(0, Some(2), 1)], value);
+
+        assert_eq!(
+            result.bytes().as_ptr() as usize,
+            buffer_before,
+            "slice_assign copied a uniquely-owned destination instead of writing in place"
+        );
+        assert_eq!(
+            result.storage::<f32>(),
+            [1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+    }
+
+    /// The other half of the #5575 contract: a destination that is still
+    /// shared must take the copy-on-write copy and leave the other holder
+    /// untouched.
+    #[test]
+    fn test_slice_assign_shared_destination_copies() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![0.0f32; 8], [8]));
+        let alias = tensor.clone();
+
+        let value = FlexTensor::from_data(TensorData::new(vec![1.0f32, 2.0], [2]));
+        let result = slice_assign(tensor, &[Slice::new(0, Some(2), 1)], value);
+
+        assert_ne!(
+            result.bytes().as_ptr() as usize,
+            alias.bytes().as_ptr() as usize,
+            "slice_assign wrote through a shared destination"
+        );
+        assert_eq!(result.storage::<f32>()[..2], [1.0, 2.0]);
+        assert_eq!(alias.storage::<f32>(), [0.0f32; 8]);
     }
 }

--- a/crates/burn-flex/src/tensor.rs
+++ b/crates/burn-flex/src/tensor.rs
@@ -284,8 +284,13 @@ impl FlexTensor {
         }
     }
 
-    /// Copy to contiguous layout if needed.
-    pub fn to_contiguous(&self) -> Self {
+    /// Copy to contiguous layout if needed, consuming `self`.
+    ///
+    /// Prefer this over [`Self::to_contiguous`] when you own the tensor and
+    /// will mutate it through [`Self::storage_mut`]: the borrowing form has
+    /// to hand back a second `Arc` handle, which makes the later
+    /// copy-on-write check see a shared buffer.
+    pub(crate) fn into_contiguous(self) -> Self {
         // Fast path requires the logical tensor to cover the whole buffer.
         // A contiguous prefix view (e.g. [8, 5] sliced to [5, 5]) has
         // canonical strides and offset 0 but an oversized buffer, and would
@@ -295,7 +300,7 @@ impl FlexTensor {
             && self.layout.start_offset() == 0
             && self.data.len() == self.layout.num_elements() * dtype_size(self.dtype)
         {
-            return self.clone();
+            return self;
         }
 
         // Copy data to new contiguous buffer
@@ -320,6 +325,11 @@ impl FlexTensor {
             }
             _ => panic!("Unsupported dtype for contiguous copy: {:?}", self.dtype),
         }
+    }
+
+    /// Copy to contiguous layout if needed.
+    pub fn to_contiguous(&self) -> Self {
+        self.clone().into_contiguous()
     }
 
     fn copy_contiguous<E: Element + bytemuck::Pod>(&self) -> Self {


### PR DESCRIPTION
Fixes #5575.

On the flex backend, `slice_assign` copies the entire destination tensor on every
call, so it costs O(destination) even when the destination is uniquely owned. On
the reporter's benchmark a small row write into a `[capacity, 4]` store scales
with `capacity`, which contradicts burn-flex's documented "in-place mutation when
uniquely owned".

## Cause

`slice_write_impl` takes its destination by value and then does

```rust
let mut tensor = tensor.to_contiguous();
```

`to_contiguous` borrows, so on its already-contiguous fast path it has to hand
back `self.clone()`, a second `Arc` handle onto the same buffer. The `let` only
*shadows* the parameter; the parameter is never moved, so it stays alive to the
end of the function still holding its handle. `Arc::strong_count` is therefore 2
by the time `storage_mut()` reaches `Arc::make_mut`, and the copy-on-write check
copies the whole buffer regardless of who actually owned the tensor.

## Fix

Turned the contiguous copy into a consuming `into_contiguous(self)`, whose fast
path returns `self` rather than a clone, and pointed `slice_write_impl` at it.
`to_contiguous(&self)` stays as it was and now delegates (`self.clone()
.into_contiguous()`), so the fast-path predicate has a single definition and the
two cannot drift. The cold path pays one extra refcount bump ahead of a full
buffer copy.

No second handle is created, so `storage_mut()` sees the real refcount and writes
in place when the caller owned the tensor. A genuinely shared destination still
takes the copy-on-write copy, exactly as before.

I kept `into_contiguous` crate-private since `slice_write_impl` is its only
caller; happy to make it `pub` for parity with `to_contiguous` if you'd prefer.

Two scope notes:

- I checked the crate's other `let t = t.to_contiguous()` sites.
  `slice_write_impl` is the only one that shadows an owned binding and then
  mutates through `storage_mut`; the rest are read-only or already take
  `mut tensor` directly, so the extra handle costs them nothing. This stays a
  one-concern change.
- `into_contiguous` keeps its whole-buffer length check, which is there (#4855)
  for callers that read `storage()` by length. `slice_write_impl` is not one of
  them, so after review it uses the crate's usual in-place predicate instead
  (`is_unique() && layout().is_contiguous() && layout().start_offset() == 0`, as
  in `bool.rs:194` and `unary.rs:81`) and a uniquely-owned contiguous *prefix
  view* destination is now written in place as well. That covers the
  `store.narrow(..)` then `slice_assign` pattern. A *shared* prefix view is still
  compacted: letting `Arc::make_mut` take that copy would duplicate the parent's
  whole buffer rather than just the view. One consequence worth naming is that
  `slice_assign` can now return a tensor whose buffer is longer than its shape,
  and which holds the parent allocation alive, exactly as `slice`, `narrow` and
  `unary_op_typed` already do.

## Measurements

20 000 `slice_assign` calls writing a `[1, 4]` row into a `[capacity, 4]` store,
release build:

| capacity | before | after |
| ---: | ---: | ---: |
| 1 000 | 2 255 ns/op | 706 ns/op |
| 10 000 | 13 446 ns/op | 641 ns/op |
| 100 000 | 122 990 ns/op | 624 ns/op |

## Testing

Two new tests pinning both halves of the ownership contract:

- `test_slice_assign_unique_destination_writes_in_place` asserts the returned
  tensor's buffer address is unchanged. It fails on `main` and passes with the
  fix.
- `test_slice_assign_shared_destination_copies` asserts a cloned destination
  still gets the copy-on-write copy and the other holder is left untouched. This
  one passes either way by design; it exists so the guarantee the fix relies on
  can't be quietly broken later.

Both follow the crate's existing `test_clone_is_cheap` / `test_cow_on_mutation`
pointer-comparison idiom.

Three more cover the prefix-view path added in review:

- `test_slice_assign_unique_prefix_view_writes_in_place` fails on the first
  commit (the buffer pointer moves), and asserts the rows past the logical prefix
  are untouched.
- `test_slice_assign_shared_prefix_view_compacts` fails `40 != 25` if the
  `is_unique()` conjunct is dropped.
- `test_slice_assign_unique_non_prefix_destinations_are_normalized` pins the
  other two conjuncts. Before it, dropping either `is_contiguous()` or
  `start_offset() == 0` left all 395 tests green: nothing in the suite hands
  `slice_assign` an offset or transposed destination, and the 1-D and 2-D
  branches compute indices from canonical strides with no `start_offset` term.

`cargo test -p burn-flex` is green (396 tests), as are `cargo xtask check format`
and `cargo xtask check lint` across the workspace.

I used an AI assistant while investigating and writing this. I have read, tested
and understood every line, and can explain the reasoning behind it.
