### PR TITLE
feat(cubecl): implement integer powi operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2304,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2440,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "cubecl-common",
  "darling 0.24.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "darling 0.24.1",
  "inflections",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5b37ec4050904db134f8d57c1094def98f32e167#5b37ec4050904db134f8d57c1094def98f32e167"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
 dependencies = [
  "derive-new",
  "serde",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
 ]
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c454d22aa024ccba5de1e402e6d279b4384c2464#c454d22aa024ccba5de1e402e6d279b4384c2464"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2304,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2440,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "cubecl-common",
  "darling 0.24.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "darling 0.24.1",
  "inflections",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a98ce524d928685d0cb1de9933faab4b607c1ba#5a98ce524d928685d0cb1de9933faab4b607c1ba"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5e39cce2c02063baf387f0d5353631b775e4c31e#5e39cce2c02063baf387f0d5353631b775e4c31e"
 dependencies = [
  "derive-new",
  "serde",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
 ]
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc75b24277ba56100f4bff473dc1365b954ed424#cc75b24277ba56100f4bff473dc1365b954ed424"
+source = "git+https://github.com/tracel-ai/cubek?rev=f0a96affcec13307fd17d5325fc25a83aaa0a758#f0a96affcec13307fd17d5325fc25a83aaa0a758"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,11 +221,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "cc75b24277ba56100f4bff473dc1365b954ed424" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5e39cce2c02063baf387f0d5353631b775e4c31e" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5e39cce2c02063baf387f0d5353631b775e4c31e" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5e39cce2c02063baf387f0d5353631b775e4c31e" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5e39cce2c02063baf387f0d5353631b775e4c31e" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "f0a96affcec13307fd17d5325fc25a83aaa0a758" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,11 +221,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5b37ec4050904db134f8d57c1094def98f32e167" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5b37ec4050904db134f8d57c1094def98f32e167" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5b37ec4050904db134f8d57c1094def98f32e167" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5b37ec4050904db134f8d57c1094def98f32e167" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c454d22aa024ccba5de1e402e6d279b4384c2464" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a98ce524d928685d0cb1de9933faab4b607c1ba" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "cc75b24277ba56100f4bff473dc1365b954ed424" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend-tests/tests/fusion/padded_layout.rs
+++ b/crates/burn-backend-tests/tests/fusion/padded_layout.rs
@@ -1,0 +1,66 @@
+use super::*;
+use burn_fusion::inspect::{BlockKind, FusionInspector};
+use burn_tensor::{TensorData, s};
+
+/// Exercise the layout vote and strided reads with storage whose padding does
+/// not depend on the backend allocator. The output planner tests separately
+/// verify the chosen strides and that padded reads cannot use `SameAsRef`.
+#[test]
+fn padded_channels_last_input_fuses_and_computes_correctly() {
+    test_stream().executes(|| {
+        let device = Default::default();
+        // Cover both an odd channel count and the vectorizable 48-channel case.
+        for channels in [3, 48] {
+            let [batch, height, width] = [2, 3, 5];
+            // Removing 128 elements preserves 256-byte alignment for both the
+            // f32 and f16 suites, allowing a metadata-only slice.
+            let pitch = channels + 128;
+            let mut storage = vec![-10000.0f32; batch * height * width * pitch];
+            let mut expected = vec![0.0f32; batch * channels * height * width];
+            for n in 0..batch {
+                for h in 0..height {
+                    for w in 0..width {
+                        for c in 0..channels {
+                            let value = ((n * height + h) * width + w) as f32 + c as f32;
+                            storage[((n * height + h) * width + w) * pitch + c] = value;
+                            expected[((n * channels + c) * height + h) * width + w] =
+                                (value + c as f32) * 2.0;
+                        }
+                    }
+                }
+            }
+            let input = TestTensor::<4>::from_data(
+                TensorData::new(storage, [batch, height, width, pitch]),
+                &device,
+            )
+            .slice(s![.., .., .., 0..channels])
+            .permute([0, 3, 1, 2]);
+            // Materialize the view before the elementwise chain is traced.
+            let _ = input.clone().into_data();
+
+            let bias = TestTensor::<4>::from_data(
+                TensorData::new(
+                    (0..channels).map(|c| c as f32).collect::<Vec<_>>(),
+                    [1, channels, 1, 1],
+                ),
+                &device,
+            );
+            device.sync().unwrap();
+            let inspector = FusionInspector::install(burn_tensor::StreamId::current());
+            let output = (input.clone() + bias).mul_scalar(2.0);
+            output.into_data().assert_eq(
+                &TensorData::new(expected, [batch, channels, height, width]),
+                false,
+            );
+            let reports = inspector.drain();
+            assert!(
+                !reports.is_empty()
+                    && reports
+                        .iter()
+                        .flat_map(|report| &report.blocks)
+                        .all(|block| { matches!(block.kind, BlockKind::Fused { .. }) }),
+                "the elementwise chain must execute through fusion: {reports:?}",
+            );
+        }
+    });
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/powi.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/powi.rs
@@ -14,6 +14,16 @@ fn should_support_powi_broadcast() {
 }
 
 #[test]
+fn should_support_powi_scalar() {
+    let tensor = TestTensorInt::<1>::from([-2, 3, 4]);
+
+    let output = tensor.powi_scalar(3);
+    let expected = TensorData::from([-8, 27, 64]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
 #[should_panic(expected = "The provided tensors have incompatible shapes.")]
 fn should_panic_powi_incompatible_shapes() {
     // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.

--- a/crates/burn-cubecl-fusion/src/base.rs
+++ b/crates/burn-cubecl-fusion/src/base.rs
@@ -9,6 +9,7 @@ use cubecl::{
     client::Client,
     ir::AddressType,
     prelude::{TensorArg, TensorBinding},
+    zspace::Tiling,
 };
 
 /// Defines a fallback operation when fusion isn't possible.
@@ -70,6 +71,7 @@ impl CubeFusionHandle {
             handle: self.handle.binding(),
             strides: self.strides.clone(),
             shape,
+            tiling: Tiling::UNTILED,
         }
     }
 

--- a/crates/burn-cubecl/src/kernel/binary_int.rs
+++ b/crates/burn-cubecl/src/kernel/binary_int.rs
@@ -7,7 +7,7 @@ use burn_backend::TensorMetadata;
 use burn_backend::cubecl::dtype_to_storage_type;
 use cubecl::{
     calculate_cube_count_elemwise,
-    prelude::*,
+    prelude::{polyfills::powi_int, *},
     std::tensor::layout::linear::{LinearView, LinearViewMut},
 };
 
@@ -26,6 +26,7 @@ pub(crate) struct BitwiseOrOp;
 pub(crate) struct BitwiseXorOp;
 pub(crate) struct BitwiseShrOp;
 pub(crate) struct BitwiseShlOp;
+pub(crate) struct PowiOp;
 
 impl BinaryOpIntFamily for BitwiseAndOp {
     type BinaryOp<C: Int, N: Size> = Self;
@@ -44,6 +45,10 @@ impl BinaryOpIntFamily for BitwiseShrOp {
 }
 
 impl BinaryOpIntFamily for BitwiseShlOp {
+    type BinaryOp<C: Int, N: Size> = Self;
+}
+
+impl BinaryOpIntFamily for PowiOp {
     type BinaryOp<C: Int, N: Size> = Self;
 }
 
@@ -79,6 +84,13 @@ impl<T: Int, N: Size> BinaryOpInt<T, N> for BitwiseShrOp {
 impl<T: Int, N: Size> BinaryOpInt<T, N> for BitwiseShlOp {
     fn execute(lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
         lhs << rhs
+    }
+}
+
+#[cube]
+impl<T: Int, N: Size> BinaryOpInt<T, N> for PowiOp {
+    fn execute(lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
+        powi_int(lhs, Vector::<i32, N>::cast_from(rhs))
     }
 }
 

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -750,12 +750,15 @@ impl IntTensorOps<Self> for CubeBackend {
         unfold(tensor, dim, size, step)
     }
 
-    // TODO
-    // fn int_powi(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
-    //     todo!()
-    // }
+    fn int_powi(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
+        launch_binop_int::<kernel::PowiOp>(lhs, rhs)
+    }
 
-    // fn int_powi_scalar_impl(lhs: IntTensor<Self>, rhs: Scalar) -> IntTensor<Self> {
-    //     todo!()
-    // }
+    fn int_powi_scalar_impl(lhs: IntTensor<Self>, rhs: Scalar) -> IntTensor<Self> {
+        let dtype = lhs.dtype;
+        launch_scalar_binop_int::<kernel::PowiOp>(
+            lhs,
+            InputScalar::new(rhs, dtype_to_storage_type(dtype)),
+        )
+    }
 }

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -187,6 +187,7 @@ impl CubeTensor {
             handle: self.handle.binding(),
             strides: self.meta.strides,
             shape: self.meta.shape,
+            tiling: self.meta.tiling,
         }
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/5564#pullrequestreview-5116214088

Fixes `should_support_powi_broadcast`, as highlighted by previous macos CI failures:
```
thread 'tensor::int::ops::powi::should_support_powi_broadcast' (34423) panicked at crates/burn-backend-tests/tests/common/../tensor/int/ops/powi.rs:13:24:
Tensors are not eq:
  => Position 2: 8 != 9
  => Position 5: 26 != 27
```

### Changes

Implement `int_powi` and `int_powi_scalar` for cubecl backends.

### Testing

Unit tests
