### PR TITLE
perf(fusion): let a padded tensor vote for the block's layout

### DIFF
--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -10,6 +10,8 @@ mod fusion_shape;
 mod inplace;
 mod int_bitwise;
 mod nhwc_relayout;
+#[cfg(feature = "cube")]
+mod padded_layout;
 mod reduce_broadcasted;
 mod reduce_logical;
 

--- a/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
@@ -36,6 +36,34 @@ pub type DimOrder = Shape;
 /// arbitrary and carries no traffic — but they keep a position in the returned
 /// order so it stays a permutation of `0..rank`.
 pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
+    dim_order_inner(shape, strides, Padding::Rejected)
+}
+
+/// The dimension order of a tensor whose dimensions nest without overlapping,
+/// or `None` if they do not.
+///
+/// Weaker than [dim_order], which additionally requires the tensor to fill its
+/// buffer. A dimension may sit at a larger stride than the extents inside it
+/// need, which is what a pitched or tile-aligned allocation produces: 48
+/// channels held innermost on a 64-element tile have stride 64 where a dense
+/// tensor would have 48.
+///
+/// Such a tensor still has a well defined dimension order, and a kernel may still
+/// *iterate* it in that order — the padding costs nothing there, because the
+/// order alone decides which reads are linear. What the tensor may not be is
+/// treated as a flat run of elements, so anything reinterpreting a buffer must
+/// keep asking [dim_order].
+pub fn nested_dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
+    dim_order_inner(shape, strides, Padding::Allowed)
+}
+
+#[derive(Clone, Copy)]
+enum Padding {
+    Allowed,
+    Rejected,
+}
+
+fn dim_order_inner(shape: &[usize], strides: &[usize], padding: Padding) -> Option<DimOrder> {
     let rank = shape.len();
 
     if rank != strides.len() {
@@ -54,10 +82,16 @@ pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
         if shape[axis] == 1 {
             continue;
         }
-        if strides[axis] != expected {
-            return None;
+        match padding {
+            // A gap is what makes the tensor padded rather than dense; an
+            // overlap is not a layout at all.
+            Padding::Allowed if strides[axis] < expected => return None,
+            Padding::Rejected if strides[axis] != expected => return None,
+            _ => {}
         }
-        expected *= shape[axis];
+        // Where the stride is exactly `expected` this is `expected *= shape[axis]`,
+        // so the dense walk is the padded one with the gaps taken out.
+        expected = strides[axis] * shape[axis];
     }
 
     Some(Shape::from(order))
@@ -263,5 +297,72 @@ mod tests {
     fn order_is_a_permutation() {
         assert!(is_contiguous_order(&[0, 1, 2, 3]));
         assert!(!is_contiguous_order(&[0, 2, 3, 1]));
+    }
+
+    #[test]
+    fn a_dense_tensor_nests_in_the_order_it_is_dense_in() {
+        let shape = [2, 48, 16, 16];
+
+        for strides in [
+            [48 * 16 * 16, 16 * 16, 16, 1],
+            [16 * 16 * 48, 1, 16 * 48, 48],
+        ] {
+            let dense = dim_order(&shape, &strides);
+            assert!(dense.is_some());
+            assert_eq!(nested_dim_order(&shape, &strides), dense);
+        }
+    }
+
+    #[test]
+    fn padding_under_the_innermost_dimension_keeps_the_nhwc_order() {
+        let shape = [2, 48, 16, 16];
+        let strides = [16 * 16 * 64, 1, 16 * 64, 64];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 2, 3, 1]))
+        );
+    }
+
+    #[test]
+    fn padding_above_the_innermost_dimension_is_nesting_too() {
+        let shape = [4, 8];
+        let strides = [16, 1];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 1]))
+        );
+    }
+
+    #[test]
+    fn overlapping_dimensions_are_not_an_order_under_either() {
+        let shape = [4, 8];
+        let strides = [4, 1];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(nested_dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn a_broadcast_dimension_still_cannot_vote() {
+        let shape = [2, 48, 16, 16];
+        let strides = [0, 1, 0, 0];
+
+        assert_eq!(nested_dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn size_one_dimensions_neither_pad_nor_constrain_nesting() {
+        let shape = [1, 48, 1, 1];
+        let strides = [48, 1, 48, 48];
+
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            dim_order(&shape, &strides)
+        );
+        assert!(nested_dim_order(&shape, &strides).is_some());
     }
 }

--- a/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
@@ -29,8 +29,8 @@ pub type DimOrder = Shape;
 /// not dense.
 ///
 /// Dense means the strides are exactly a permutation of contiguous strides: no
-/// gaps, no overlap, no broadcasting. A tensor that is not dense cannot be
-/// described by a dimension order, and a block cannot adopt its layout.
+/// gaps, no overlap, no broadcasting. Use [nested_dim_order] when only an
+/// iteration order is needed and gaps in storage are acceptable.
 ///
 /// Dimensions of size one are ignored while checking density — their stride is
 /// arbitrary and carries no traffic — but they keep a position in the returned
@@ -42,17 +42,18 @@ pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
 /// The dimension order of a tensor whose dimensions nest without overlapping,
 /// or `None` if they do not.
 ///
-/// Weaker than [dim_order], which additionally requires the tensor to fill its
-/// buffer. A dimension may sit at a larger stride than the extents inside it
+/// Weaker than [dim_order], which additionally requires consecutive elements
+/// without gaps. A dimension may sit at a larger stride than the extents inside it
 /// need, which is what a pitched or tile-aligned allocation produces: 48
 /// channels held innermost on a 64-element tile have stride 64 where a dense
 /// tensor would have 48.
 ///
-/// Such a tensor still has a well defined dimension order, and a kernel may still
-/// *iterate* it in that order — the padding costs nothing there, because the
-/// order alone decides which reads are linear. What the tensor may not be is
-/// treated as a flat run of elements, so anything reinterpreting a buffer must
-/// keep asking [dim_order].
+/// Iterating in this order can improve locality, but reads must still use the
+/// tensor's actual strides. Gaps can affect memory transactions and vectorization;
+/// accepting an order does not guarantee dense-access performance. This also
+/// accepts sliced views whose dimensions satisfy the same nesting condition.
+/// Anything reinterpreting a buffer as a flat run of elements must keep asking
+/// [dim_order].
 pub fn nested_dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
     dim_order_inner(shape, strides, Padding::Allowed)
 }

--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -8,7 +8,7 @@ use crate::{
         codegen::ir::{FuseArg, FuseOp, LayoutInfo},
         launch::{
             HandleInput,
-            layout::{DimOrder, dim_order, is_contiguous_order, strides_for},
+            layout::{DimOrder, dim_order, is_contiguous_order, nested_dim_order, strides_for},
         },
         settings::{FuseSettings, RefLayoutSetting},
         trace::{FuseResources, RegisterTensor, RuntimeLayout, TensorView, block::FuseBlock},
@@ -466,9 +466,13 @@ impl<'a> OutputPlanner<'a> {
                 }
             };
 
-            let Some(order) = dim_order(voter_shape, &input.handle.strides) else {
-                // Not dense: sliced, broadcast, or otherwise not describable as an
-                // order. The block cannot adopt a layout it cannot express.
+            // Padding is tolerated where [dim_order] would reject it: a pitched
+            // allocation leaves every convolution output with a gap at its
+            // innermost dimension, and demanding density would drop exactly the
+            // tensors this vote exists to notice. Only the order is voted on; the
+            // output is still allocated dense in the winning order, and a padded
+            // input is read through the strided path as before.
+            let Some(order) = nested_dim_order(voter_shape, &input.handle.strides) else {
                 continue;
             };
 

--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -404,9 +404,10 @@ impl<'a> OutputPlanner<'a> {
     /// it. That makes the best choice the plurality of the inputs, weighted by
     /// the bytes each one moves.
     ///
-    /// Only inputs of exactly this shape vote. A broadcast parameter is read from
-    /// cache whatever the order is, and a differently shaped input can never be
-    /// `SameAsRef` regardless, so neither has a stake in the outcome.
+    /// Normally only inputs of exactly this shape vote. This heuristic favors
+    /// full-sized inputs over broadcast parameters, which typically benefit from
+    /// cache reuse. A voter need not qualify for `SameAsRef`: padded inputs can
+    /// benefit from the chosen order while still using their own strides.
     ///
     /// A concatenated operand is the exception, and votes despite being shorter
     /// than the output along the axis it is joined on: `concat` computes its
@@ -467,10 +468,10 @@ impl<'a> OutputPlanner<'a> {
             };
 
             // Padding is tolerated where [dim_order] would reject it: a pitched
-            // allocation leaves every convolution output with a gap at its
-            // innermost dimension, and demanding density would drop exactly the
-            // tensors this vote exists to notice. Only the order is voted on; the
-            // output is still allocated dense in the winning order, and a padded
+            // allocation can leave gaps between channel rows when the channel
+            // count is not aligned. Nested sliced views can vote too, regardless
+            // of backend. Only the order is voted on; the output is still
+            // allocated dense in the winning order, and a padded
             // input is read through the strided path as before.
             let Some(order) = nested_dim_order(voter_shape, &input.handle.strides) else {
                 continue;
@@ -1109,6 +1110,85 @@ mod tests {
 
         assert!(may_permute_layout(&settings, &[elemwise_op()]));
         assert!(may_permute_layout(&settings, &[]));
+    }
+
+    #[test]
+    fn padded_input_selects_dense_nhwc_output_without_same_as_ref() {
+        use burn_ir::TensorStatus;
+        use burn_std::DType;
+
+        let device = cubecl::test_device();
+        let client = device.client();
+        for channels in [3, 48] {
+            let shape = Shape::from([2, channels, 3, 5]);
+            let pitch = 64;
+            let padded_strides = Strides::new(&[3 * 5 * pitch, 1, 5 * pitch, pitch]);
+            let input = TensorIr {
+                id: TensorId::new(0),
+                shape: shape.clone(),
+                dtype: DType::F32,
+                status: TensorStatus::ReadOnly,
+            };
+            let output = TensorIr {
+                id: TensorId::new(1),
+                status: TensorStatus::NotInit,
+                ..input.clone()
+            };
+            let blocks = vec![FuseBlock {
+                settings: settings(RefLayoutSetting::Any, true),
+                shape_ref: shape.clone(),
+                ops: vec![elemwise_op()],
+                reads: BTreeMap::from([(input.id, vec![elemwise_op()])]),
+                writes: BTreeMap::from([(output.id, vec![elemwise_op()])]),
+            }];
+            let mut resources = FuseResources::default();
+            resources.inputs.insert(FuseType::F32, input.clone());
+            resources.outputs.insert(FuseType::F32, output.clone());
+            let mut plan = LaunchPlan::new(&blocks);
+            plan.handle_inputs
+                .push(HandleInput::Normal(NormalHandleInput {
+                    relative_id: input.id,
+                    global_ir: input,
+                    precision: FuseType::F32,
+                    handle: CubeFusionHandle {
+                        client: client.clone(),
+                        handle: client.empty(2 * 3 * 5 * pitch * 4),
+                        device: device.clone(),
+                        dtype: DType::F32,
+                        strides: padded_strides.clone(),
+                        qparams: None,
+                    },
+                    vector_size: 1,
+                    broadcated: false,
+                    orig_strides: padded_strides,
+                }));
+            let mut context = Context {
+                tensors: [(output.id, output)].into_iter().collect(),
+                handles: Default::default(),
+                scalars: Default::default(),
+                shapes_relative2global: Default::default(),
+                ranges: Vec::new(),
+            };
+
+            OutputPlanner::new(&resources, &blocks).run(&client, &device, &mut context, &mut plan);
+
+            let HandleOutput::Owned { handle, .. } = &plan.handle_outputs[0] else {
+                panic!("a padded input must not be reused as a dense output");
+            };
+            let expected = Strides::new(&[3 * 5 * channels, 1, 5 * channels, channels]);
+            assert_eq!(handle.strides, expected);
+            assert!(matches!(
+                &plan.blocks[0].reference,
+                ReferenceSelection::Concrete { strides, .. } if strides == &expected
+            ));
+            let FuseOp::Assign(read) = &plan.blocks[0].reads[&TensorId::new(0)][0] else {
+                panic!("expected an input read");
+            };
+            assert!(matches!(
+                read.input,
+                FuseArg::Input(0, _, LayoutInfo::Unknown)
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

A fused block picks the dimension order of its output by a byte-weighted vote among its inputs, so that a block fed a channels-last tensor iterates channels-last and reads it linearly instead of strided. The vote asked each input for its `dim_order`, which requires the tensor to fill its buffer exactly. A tile-aligned or pitched allocator does not do that: it leaves a gap under the innermost dimension, so 48 elements held innermost on a 64-element tile carry stride 64 where a dense tensor would carry 48.

Such a tensor is not dense, so it could not vote. With no voters the block kept a contiguous reference, wrote its output vectorized and read its large channels-last input one element at a time. Nothing failed; the layout propagation simply never fired on a backend whose allocator pitches rows, for every channel count that is not tile-aligned. A backend with dense allocations took the fast path all along, which is why the gap only showed up as a difference between backends.

`nested_dim_order` accepts a gap (padding) and still rejects an overlap, and the vote now uses it. That is enough because the vote only decides the order the output is allocated in, and the output is allocated dense in that order either way; a padded input whose strides then differ from the reference is read through the strided path, since `SameAsRef` compares strides exactly. `dim_order` is unchanged wherever a buffer is reinterpreted as a flat run of elements.

Measured on CUDA (one L4), warm, median of ten: an elementwise normalization plus activation over a channels-last view of a [4, 48, 384, 384] tensor went from 6.28x the contiguous case to 1.10x; a convolutional encoder pass 1.58x faster; a full forward pass 1.6x faster; a training step 1.11x faster.

### Testing

Six unit tests cover the new `nested_dim_order` behaviour in `burn-cubecl-fusion`'s layout helper: `a_dense_tensor_nests_in_the_order_it_is_dense_in`, `padding_under_the_innermost_dimension_keeps_the_nhwc_order`, `padding_above_the_innermost_dimension_is_nesting_too`, `overlapping_dimensions_are_not_an_order_under_either`, `a_broadcast_dimension_still_cannot_vote`, and `size_one_dimensions_neither_pad_nor_constrain_nesting`.

### Reproduction

https://github.com/Marc-AnthonyG/burn-reproduction/tree/main/cases/padded-tensors-vote-layout

Run with `cargo run --release -p padded-tensors-vote-layout --features cuda`,