### PR TITLE
perf(cubecl): scatter-add runs one unit per value with atomic adds

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/scatter.rs
+++ b/crates/burn-backend-tests/tests/cubecl/scatter.rs
@@ -3,6 +3,25 @@ use burn_tensor::Distribution;
 use burn_tensor::{Device, IndexingUpdateOp, Tolerance};
 
 #[test]
+fn scatter_add_handles_nan_and_infinity() {
+    let device = Device::default();
+    let tensor = TestTensor::<1>::from_data([f32::NAN, f32::INFINITY, 0.0], &device);
+    let values = TestTensor::<1>::from_data([1.0, f32::NEG_INFINITY, f32::NAN], &device);
+    let indices = TestTensorInt::from_ints([0, 1, 2], &device);
+    let actual = tensor
+        .scatter(0, indices, values, IndexingUpdateOp::Add)
+        .into_data()
+        .convert::<f32>();
+    assert!(
+        actual
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .all(|value| value.is_nan())
+    );
+}
+
+#[test]
 fn scatter_add_should_match_reference_2d_dim0() {
     scatter_add_matches_reference_same_shape(0, [256, 32]);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -161,9 +161,6 @@ fn should_scatter_add_2d_dim0() {
         .assert_eq(&TensorData::from([[0.0, 2.0, 6.0], [5.0, 5.0, 3.0]]), false);
 }
 
-/// Far more values than slots, every slot hit hundreds of times: a scatter
-/// that adds in parallel must still count exactly, whatever order the
-/// updates land in.
 #[test]
 fn should_scatter_add_many_values_into_few_slots() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -161,6 +161,27 @@ fn should_scatter_add_2d_dim0() {
         .assert_eq(&TensorData::from([[0.0, 2.0, 6.0], [5.0, 5.0, 3.0]]), false);
 }
 
+/// Far more values than slots, every slot hit hundreds of times: a scatter
+/// that adds in parallel must still count exactly, whatever order the
+/// updates land in.
+#[test]
+fn should_scatter_add_many_values_into_few_slots() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 4], &device);
+    let indices: Vec<i32> = (0..2 * 1000)
+        .map(|position| (position % 4) as i32)
+        .collect();
+    let indices = TestTensorInt::<2>::from_data(TensorData::new(indices, [2, 1000]), &device);
+    let values = TestTensor::<2>::ones([2, 1000], &device);
+
+    let output = tensor.scatter(1, indices, values, IndexingUpdateOp::Add);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[250.0, 250.0, 250.0, 250.0], [250.0, 250.0, 250.0, 250.0]]),
+        false,
+    );
+}
+
 #[test]
 fn should_scatter_add_2d_dim1() {
     let device = Default::default();

--- a/crates/burn-cubecl/src/kernel/index/scatter.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter.rs
@@ -78,6 +78,8 @@ fn scatter_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
 /// Only for `Add`, and only on types the device adds atomically. On floats the
 /// order the adds land in is not fixed, so the rounding of a sum can differ
 /// from one run to the next; the serial kernel is deterministic.
+/// CUDA native global-memory atomic addition for f32 (including Flex32)
+/// flushes subnormal inputs and results to sign-preserving zero.
 #[cube(launch_unchecked, address_type = "dynamic")]
 fn scatter_add_atomic_kernel<T: Numeric, I: Int>(
     input: &mut Tensor<Atomic<T>>,
@@ -156,9 +158,12 @@ fn scatter_add_atomic(
 }
 
 fn adds_atomically(tensor: &CubeTensor) -> bool {
-    tensor
-        .client
-        .properties()
+    let properties = tensor.client.properties();
+    // CPU scatter keeps one unit per row, avoiding contended atomic updates.
+    if properties.hardware.num_cpu_cores.is_some() {
+        return false;
+    }
+    properties
         .atomic_type_usage(Type::atomic(dtype_to_elem_type(tensor.dtype)))
         .contains(AtomicUsage::Add)
 }

--- a/crates/burn-cubecl/src/kernel/index/scatter.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter.rs
@@ -5,8 +5,8 @@ use crate::{
     },
     tensor::CubeTensor,
 };
-use burn_backend::cubecl::dtype_to_storage_type;
-use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type};
+use cubecl::{CubeDim, calculate_cube_count_elemwise, features::AtomicUsage, ir::Type};
 use cubecl::{prelude::*, std::FastDivmod};
 
 #[cube(launch_unchecked, address_type = "dynamic")]
@@ -69,6 +69,100 @@ fn scatter_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     }
 }
 
+/// One unit per value, each update an atomic add: the whole value tensor
+/// scatters in parallel. [`scatter_kernel`] runs one unit per output row and
+/// walks the scatter axis serially, which leaves the device nearly idle when
+/// the values far outnumber the output rows — a histogram or a bincount, where
+/// a few thousand rows receive millions of updates.
+///
+/// Only for `Add`, and only on types the device adds atomically. On floats the
+/// order the adds land in is not fixed, so the rounding of a sum can differ
+/// from one run to the next; the serial kernel is deterministic.
+#[cube(launch_unchecked, address_type = "dynamic")]
+fn scatter_add_atomic_kernel<T: Numeric, I: Int>(
+    input: &mut Tensor<Atomic<T>>,
+    indices: &Tensor<I>,
+    value: &Tensor<T>,
+    value_shape: Sequence<FastDivmod<usize>>,
+    #[comptime] dim: usize,
+    #[define(T, I)] _dtypes: [ElemType; 2],
+) {
+    let rank = value_shape.len().comptime();
+
+    let mut offset = ABSOLUTE_POS;
+    let mut offset_input = 0;
+    let mut offset_indices = 0;
+    let mut offset_value = 0;
+    let mut num_elems = 1;
+
+    #[unroll]
+    for i in 0..rank {
+        let i = rank - i - 1;
+        let (rem, coordinate) = value_shape[i].div_mod(offset);
+        offset = rem;
+
+        offset_value += coordinate * value.stride(i);
+        offset_indices += coordinate * indices.stride(i);
+        if i != dim {
+            offset_input += coordinate * input.stride(i);
+        }
+        num_elems *= value.shape(i);
+    }
+
+    if ABSOLUTE_POS >= num_elems {
+        terminate!();
+    }
+
+    let index = usize::cast_from(indices[offset_indices]);
+    let target = offset_input + index * input.stride(dim);
+    input[target].fetch_add(value[offset_value]);
+}
+
+fn scatter_add_atomic(
+    dim: usize,
+    tensor: CubeTensor,
+    indices: CubeTensor,
+    value: CubeTensor,
+) -> CubeTensor {
+    let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
+        true => tensor,
+        false => tensor.copy(),
+    };
+
+    let working_units = value.meta.num_elements();
+    let cube_dim = CubeDim::new(&indices.client, working_units);
+    let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
+    let (tensor_dtype, indices_dtype) = (tensor.dtype, indices.dtype);
+    let value_shape = shape_divmod(&value);
+
+    unsafe {
+        scatter_add_atomic_kernel::launch_unchecked(
+            &tensor.client.clone(),
+            cube_count,
+            cube_dim,
+            address_type!(tensor, indices, value),
+            tensor.clone().into_tensor_arg(),
+            indices.into_tensor_arg(),
+            value.into_tensor_arg(),
+            value_shape,
+            dim,
+            [
+                dtype_to_storage_type(tensor_dtype),
+                dtype_to_storage_type(indices_dtype),
+            ],
+        )
+    }
+    tensor
+}
+
+fn adds_atomically(tensor: &CubeTensor) -> bool {
+    tensor
+        .client
+        .properties()
+        .atomic_type_usage(Type::atomic(dtype_to_elem_type(tensor.dtype)))
+        .contains(AtomicUsage::Add)
+}
+
 fn scatter_op<Op: BinaryOpFamily>(
     dim: usize,
     tensor: CubeTensor,
@@ -117,6 +211,7 @@ pub(crate) fn scatter(
 ) -> CubeTensor {
     match is_bool {
         true => scatter_op::<OrOp>(dim, tensor, indices, value),
+        false if adds_atomically(&tensor) => scatter_add_atomic(dim, tensor, indices, value),
         false => scatter_op::<AddOp>(dim, tensor, indices, value),
     }
 }


### PR DESCRIPTION
### Changes

The scatter kernel ran one unit per output row and walked the scatter axis serially. That leaves the device nearly idle whenever the values far outnumber the output rows: a histogram of a million values into a few thousand bins ran on a thousand units each looping over every value, and cost the same whether the batch was 32 or 128.

For `Add`, on a type the device adds atomically, a second kernel now runs one unit per value and applies each update with an atomic add. The serial kernel stays for `Assign`, `Mul` and `Or`, whose order matters or which have no atomic form, and for types without atomic support. On floats the order the adds land in is not fixed, so a sum's rounding can differ between runs where the serial kernel was deterministic.

Measured on an L4 (CUDA), a 1-D convolution bank whose counting scatters 1.6 million values into 8,192 slots sixteen times a pass, same session, medians of 20 with the first pass of each binary discarded: the training step went from 95.9 to 81.2 ms, repeated 81.5 ms (-15%). In isolation the two scatters of one dilation went from 1.45 ms to about 0.3 ms.

### Testing

`should_scatter_add_many_values_into_few_slots` (`tests/tensor/float/ops/gather_scatter.rs`) scatters two thousand ones into eight slots, so every slot is hit hundreds of times, and checks the counts come out exact.

### Reproduction

https://github.com/Marc-AnthonyG/burn-reproduction/tree/main/cases/scatter-add-atomic

Run with `cargo run --release -p scatter-add-atomic --features cuda`.

##Metal
<img width="844" height="164" alt="Screenshot 2026-09-08 at 2 37 53 PM" src="https://github.com/user-attachments/assets/575eb050-6adb-4579-8132-af26a008213b" />

## CUDA
<img width="862" height="161" alt="Screenshot 2026-09-08 at 3 21 29 PM" src="https://github.com/user-attachments/assets/71a232cf-e005-4c76-a035-738378535635" />
