### PR TITLE
perf(fusion): settle only the unfusable head of a block

### DIFF
--- a/crates/burn-fusion/src/search/block.rs
+++ b/crates/burn-fusion/src/search/block.rs
@@ -29,6 +29,9 @@ pub struct Block<O> {
     /// reason about the original dependency graph through the recursive merging.
     constituents: SubGraph,
     ordering: Vec<usize>,
+    /// For each builder, the index into `operations` of the operation on which it reported
+    /// [Closed](FuserStatus::Closed); `None` while it is still open.
+    closed_at: Vec<Option<usize>>,
     /// The start position in the relative execution stream.
     pub start_pos: usize,
     /// The end position in the relative execution stream.
@@ -139,6 +142,7 @@ impl<O: NumOperations> Block<O> {
             freed: HashSet::new(),
             constituents: SubGraph::empty(),
             ordering: Vec::new(),
+            closed_at: vec![None; builders.len()],
             start_pos: usize::MAX,
             end_pos: usize::MIN,
         }
@@ -150,7 +154,13 @@ impl<O: NumOperations> Block<O> {
     }
 
     /// Optimize the block.
-    pub fn optimize(mut self) -> BlockOptimization<O> {
+    ///
+    /// `fresh_builders` are the builders as a new search starts them: they tell, after an
+    /// unfusable head, which operations no builder would even start on.
+    pub fn optimize(
+        mut self,
+        fresh_builders: &[Box<dyn OperationFuser<O>>],
+    ) -> BlockOptimization<O> {
         match find_best_optimization_index(&mut self.builders) {
             BestOptimization::Found { index, score } => {
                 let opt = self.builders[index].finish();
@@ -167,12 +177,63 @@ impl<O: NumOperations> Block<O> {
                 BlockOptimization::new(strategy, self.ordering)
             }
             BestOptimization::NotFound => {
+                // Nothing fuses from the head of this block. Every builder saw the operations
+                // past the point where the last of them closed only as continuations of that
+                // head; none has tried them from a clean start. Settle the head unfused, along
+                // with whatever follows it that no builder would start on, and leave the rest
+                // to the next search — as a hole or as the next segment — where a fresh
+                // builder gets to fuse it.
+                let settled = self.operations_settled_once_every_builder_closed();
+                let settled =
+                    self.operations_settled_while_no_builder_would_start(settled, fresh_builders);
+                if settled < self.operations.len() {
+                    self.ordering.drain(settled..);
+                }
+
                 let strategy = ExecutionStrategy::Operations {
                     ordering: Arc::new(self.ordering.clone()),
                 };
                 BlockOptimization::new(strategy, self.ordering)
             }
         }
+    }
+
+    /// Extends `settled` over the operations a fresh builder would neither keep open nor
+    /// be ready on, stopping at the first one some builder wants: that is where the next
+    /// search should begin, and everything before it would only make one-op segments.
+    fn operations_settled_while_no_builder_would_start(
+        &self,
+        mut settled: usize,
+        fresh_builders: &[Box<dyn OperationFuser<O>>],
+    ) -> usize {
+        while let Some(operation) = self.operations.get(settled) {
+            let wanted = fresh_builders.iter().any(|builder| {
+                let mut probe = builder.clone_dyn();
+                probe.fuse(operation);
+                matches!(probe.status(), FuserStatus::Open) || probe.properties().ready
+            });
+            if wanted {
+                break;
+            }
+            settled += 1;
+        }
+        settled
+    }
+
+    /// How many operations, from the head, it takes to close every builder. The operation
+    /// that closed the last builder is settled with the head: every builder was still waiting
+    /// on it, and a block that closes on its second operation keeps executing as one segment,
+    /// as it always has. A builder still open at the end counts the whole block: there is no
+    /// point after which it stopped wanting more.
+    fn operations_settled_once_every_builder_closed(&self) -> usize {
+        self.closed_at
+            .iter()
+            .map(|closed_at| match closed_at {
+                Some(index) => index + 1,
+                None => self.operations.len(),
+            })
+            .max()
+            .unwrap_or(self.operations.len())
     }
 
     /// Returns if the block contains any of the provided [tensors](TensorIr).
@@ -309,8 +370,12 @@ impl<O: NumOperations> Block<O> {
             self.end_pos = pos + 1;
         }
 
-        for builder in self.builders.iter_mut() {
+        let index = self.operations.len() - 1;
+        for (builder, closed_at) in self.builders.iter_mut().zip(self.closed_at.iter_mut()) {
             builder.fuse(operation);
+            if closed_at.is_none() && matches!(builder.status(), FuserStatus::Closed) {
+                *closed_at = Some(index);
+            }
         }
 
         for node in operation.nodes() {
@@ -487,6 +552,7 @@ impl<O> Clone for Block<O> {
             freed: self.freed.clone(),
             constituents: self.constituents.clone(),
             ordering: self.ordering.clone(),
+            closed_at: self.closed_at.clone(),
             start_pos: self.start_pos,
             end_pos: self.end_pos,
         }

--- a/crates/burn-fusion/src/search/optimization/blocks.rs
+++ b/crates/burn-fusion/src/search/optimization/blocks.rs
@@ -1,7 +1,7 @@
 use burn_std::config::{fusion::FusionLogLevel, log_fusion};
 
 use crate::{
-    NumOperations,
+    NumOperations, OperationFuser,
     search::{
         Block, BlockOptimization,
         graph::Dag,
@@ -60,7 +60,12 @@ impl<O: NumOperations> BlocksOptimizer<O> {
     ///    pass. Trailing unresolved positions, on the other hand, are the
     ///    natural tail of a drained block and are left in the queue for the
     ///    processor to handle in the next round.
-    pub fn optimize(mut self) -> BlocksOptimizerResult<O> {
+    ///
+    /// `fresh_builders` are the builders as a new search starts them; see [Block::optimize].
+    pub fn optimize(
+        mut self,
+        fresh_builders: &[Box<dyn OperationFuser<O>>],
+    ) -> BlocksOptimizerResult<O> {
         self = self.merging_pass();
 
         let num_ops = self.num_ops;
@@ -83,7 +88,7 @@ impl<O: NumOperations> BlocksOptimizer<O> {
         let mut resolved = vec![false; num_ops];
 
         for block in blocks {
-            let mut block_opt = block.optimize();
+            let mut block_opt = block.optimize(fresh_builders);
             for pos in block_opt.ordering.iter() {
                 resolved[*pos] = true;
             }

--- a/crates/burn-fusion/src/search/optimization/stream.rs
+++ b/crates/burn-fusion/src/search/optimization/stream.rs
@@ -111,7 +111,7 @@ impl<O: NumOperations> StreamOptimizer<O> {
     /// method, this simply remove the need for the current type to also keep track of the list of
     /// operations.
     pub fn optimize(&self, operations: &[OperationIr]) -> BlockOptimization<O> {
-        let result = BlocksOptimizer::new(self.blocks.clone()).optimize();
+        let result = BlocksOptimizer::new(self.blocks.clone()).optimize(&self.builders);
 
         let out = match result {
             BlocksOptimizerResult::Full(block_optimization) => block_optimization,

--- a/crates/burn-fusion/src/search/optimization/tests.rs
+++ b/crates/burn-fusion/src/search/optimization/tests.rs
@@ -209,8 +209,8 @@ fn within_block_order_is_not_reordered() {
     // Builder wants [a2, a1] — only reachable if we reorder within the block.
     let res = run(&ops, vec![vec![a2.clone(), a1.clone()]]);
 
-    assert_eq!(res.ordering, vec![0, 1]);
-    assert_eq!(res.strategy, operations(vec![0, 1]));
+    assert_eq!(res.ordering, vec![0]);
+    assert_eq!(res.strategy, operations(vec![0]));
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +316,71 @@ fn all_closed_without_ready_bails_out() {
     let res = opt.optimize(&ops);
     assert_eq!(res.ordering, vec![0, 1]);
     assert_eq!(res.strategy, operations(vec![0, 1]));
+}
+
+/// A dependent chain whose head matches no pattern used to run unfused as a
+/// whole, tail included. Only the head is settled; the tail goes back to the
+/// search, where its own pattern fuses it. (`within_block_order_is_not_reordered`
+/// above is the two-op case: the head runs unfused and the second op is left
+/// to the next search, since a fresh builder would start on it.)
+#[test]
+fn unfusable_head_leaves_the_tail_to_the_next_search() {
+    let head = add(100, 101, 102);
+    let t1 = add(102, 103, 104);
+    let t2 = add(104, 105, 106);
+    let ops = vec![head.clone(), t1.clone(), t2.clone()];
+    let patterns = vec![vec![t1.clone(), t2.clone()]];
+
+    let res = run(&ops, patterns.clone());
+    assert_eq!(res.ordering, vec![0]);
+    assert_eq!(res.strategy, operations(vec![0]));
+
+    let tail = vec![t1, t2];
+    let res = run(&tail, patterns);
+    assert_eq!(res.ordering, vec![0, 1]);
+    assert_eq!(res.strategy, optimization(0, 2, vec![0, 1], 2));
+}
+
+/// The op that closed the last builder is settled with the head, even when a
+/// fresh builder would start on it: every builder was waiting on that op, and
+/// the block keeps executing as one segment up to it. The `[t1, t2]` fusion is
+/// therefore not found here; the search only resumes after `t1`.
+#[test]
+fn op_that_closed_the_last_builder_is_settled_with_the_head() {
+    let head = add(100, 101, 102);
+    let t1 = add(102, 103, 104);
+    let t2 = add(104, 105, 106);
+    let never = add(300, 301, 302);
+    let ops = vec![head.clone(), t1.clone(), t2.clone()];
+
+    let res = run(&ops, vec![vec![head, never], vec![t1, t2]]);
+
+    assert_eq!(res.ordering, vec![0, 1, 2]);
+    assert_eq!(res.strategy, operations(vec![0, 1, 2]));
+}
+
+/// The same chain followed by an independent fusable block. The chain's tail
+/// is then interior — a hole — and the hole pass fuses it in the same plan.
+#[test]
+fn unfusable_head_tail_is_fused_as_a_hole() {
+    let head = add(100, 101, 102);
+    let t1 = add(102, 103, 104);
+    let t2 = add(104, 105, 106);
+    let x1 = add(200, 201, 202);
+    let x2 = add(202, 203, 204);
+    let ops = vec![head.clone(), t1.clone(), t2.clone(), x1.clone(), x2.clone()];
+
+    let res = run(&ops, vec![vec![t1, t2], vec![x1, x2]]);
+
+    assert_eq!(res.ordering, vec![0, 1, 2, 3, 4]);
+    assert_eq!(
+        res.strategy,
+        composed(vec![
+            operations(vec![0]),
+            optimization(0, 2, vec![1, 2], 2),
+            optimization(1, 2, vec![3, 4], 2),
+        ]),
+    );
 }
 
 /// A single pattern that spans two independent blocks, but the last op of


### PR DESCRIPTION
### Changes

When a dependent block is committed and no fuser has a fusion worth executing, `Block::optimize` returned the whole block as unfused operations. A block is a dependency chain, so everything after the operation that closed the fusers ran one kernel each, although a fresh fuser would have fused it: those operations only sat in that block because they depend on its head. The common heads are a lone elementwise op followed by a view of its own output, a convolution backward, or a reduction (a single fused op scores zero), which is what a backward pass is made of. On a convolutional network's training step the fusion log showed 3,588 one-op segments per step and 3,238 elementwise ops executing unfused, 2,504 of them in runs of two or more consecutive fusable ops.

Now only the head is settled: the operations up to and including the one that closed the last fuser, plus whatever follows that no fresh fuser would start on, probed by feeding it to a clone of each pristine fuser. The rest goes back to the search, either as a hole re-optimized in the same plan or as the next segment, exactly as the tail of a block that did have a fusion already did. The stream optimizer passes its pristine fusers down for the probe, and each block records the registration index at which every fuser closed.

The operation that closed the last fuser is always settled with the head, even when a fresh fuser would start on it, so a block that closes on its second operation keeps executing as one segment, as before. Leaving that operation to the search would win a fusion in some cases at the price of more segments; that is a separate decision, not taken here.

### Testing

Three tests cover the behaviour: `unfusable_head_leaves_the_tail_to_the_next_search` (an unfusable head leaves its fusable tail to the next search instead of running it unfused), `unfusable_head_tail_is_fused_as_a_hole` (that tail is fused as a hole once an independent block follows it), and `op_that_closed_the_last_builder_is_settled_with_the_head` (the operation that closed the last fuser stays with the head even when a fresh fuser would take it). One existing expectation was updated: an in-block reorder is still refused, but the second operation is no longer dragged along unfused with it.

### Reproduction

https://github.com/Marc-AnthonyG/burn-reproduction/tree/main/cases/fusion-settle-unfusable-head

Run with `cargo run --release -p fusion-settle-unfusable-head --features cuda`.