### PR TITLE
perf(autodiff): reduce a broadcast gradient over all dims at once

### DIFF
--- a/crates/burn-autodiff/src/ops/base.rs
+++ b/crates/burn-autodiff/src/ops/base.rs
@@ -10,7 +10,7 @@ use crate::{
     graph::{ComputingProperty, NodeId, NodeRef, Parent, Requirement, Step},
     tensor::AutodiffTensor,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use burn_backend::{Backend, TensorMetadata, tensor::FloatTensor};
 use burn_std::Shape;
 use core::marker::PhantomData;

--- a/crates/burn-autodiff/src/ops/base.rs
+++ b/crates/burn-autodiff/src/ops/base.rs
@@ -307,10 +307,11 @@ impl<const N: usize> Step for UntrackedOpsStep<N> {
 ///
 /// If broadcasting happened during the forward pass, the gradients will be sum along the
 /// broadcasted dimension.
-pub fn broadcast_shape<B: Backend>(mut grad: FloatTensor<B>, shape: &Shape) -> FloatTensor<B> {
+pub fn broadcast_shape<B: Backend>(grad: FloatTensor<B>, shape: &Shape) -> FloatTensor<B> {
     let shape_grad = grad.shape();
     let ndims = shape_grad.num_dims();
 
+    let mut broadcast_dims = Vec::new();
     for i in 0..ndims {
         if shape_grad[i] != shape[i] {
             if shape[i] != 1 {
@@ -319,9 +320,17 @@ pub fn broadcast_shape<B: Backend>(mut grad: FloatTensor<B>, shape: &Shape) -> F
                     shape, shape_grad, "Expected the shape of the next grad to be 1."
                 );
             }
-            grad = B::float_sum_dim(grad, i);
+            broadcast_dims.push(i);
         }
     }
 
-    grad
+    // One reduction over every broadcast dimension rather than one per
+    // dimension: a parameter broadcast over batch and space would otherwise
+    // pay a launch and an intermediate for each, the first of them nearly the
+    // size of the gradient itself.
+    match broadcast_dims.as_slice() {
+        [] => grad,
+        [dim] => B::float_sum_dim(grad, *dim),
+        dims => B::float_sum_dims(grad, dims),
+    }
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -110,6 +110,7 @@ mod powf_scalar;
 mod prod;
 mod random;
 mod recip;
+mod reduce_dims;
 mod remainder;
 mod repeat;
 mod repeat_dim;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/reduce_dims.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/reduce_dims.rs
@@ -1,0 +1,89 @@
+//! Reductions over several dimensions at once, on operands in and out of
+//! logical dimension order. Each case asks for the same answer as reducing
+//! the dimensions one at a time on a contiguous copy, so what is pinned is
+//! that folding dimensions together never changes what is summed.
+
+use super::*;
+use burn_tensor::Tolerance;
+
+/// A `[2, 3, 4, 5]` tensor held channels-last in memory, and a contiguous
+/// copy of the same values.
+fn permuted_and_contiguous() -> (TestTensor<4>, TestTensor<4>) {
+    let device = Default::default();
+    let permuted = TestTensorInt::arange(0..(2 * 3 * 4 * 5), &device)
+        .float()
+        .reshape([2, 4, 5, 3])
+        .permute([0, 3, 1, 2]);
+    permuted.device().sync().unwrap();
+
+    let contiguous = TestTensor::<4>::from_data(permuted.to_data(), &device);
+    contiguous.device().sync().unwrap();
+
+    (permuted, contiguous)
+}
+
+fn one_dim_at_a_time(tensor: TestTensor<4>, dims: &[usize]) -> TestTensor<4> {
+    dims.iter().fold(tensor, |tensor, &dim| tensor.sum_dim(dim))
+}
+
+fn assert_same(actual: TestTensor<4>, expected: TestTensor<4>) {
+    let expected = expected.into_data();
+    let actual = actual.into_data();
+
+    assert_eq!(actual.shape, expected.shape);
+    actual.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn every_non_channel_dimension_of_a_channels_last_tensor_folds_into_one() {
+    // Batch, height and width sit next to each other in channels-last memory,
+    // so this is the case that reduces in a single launch.
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    assert_same(
+        permuted.sum_dims(&[0, 2, 3]),
+        one_dim_at_a_time(contiguous, &[0, 2, 3]),
+    );
+}
+
+#[test]
+fn every_non_channel_dimension_of_a_contiguous_tensor_is_reduced_in_two() {
+    // In logical order the batch dimension is separated from height and width
+    // by the channels, so the innermost pair reduces first and the batch after.
+    let (_, contiguous) = permuted_and_contiguous();
+
+    assert_same(
+        contiguous.clone().sum_dims(&[0, 2, 3]),
+        one_dim_at_a_time(contiguous, &[0, 2, 3]),
+    );
+}
+
+#[test]
+fn dimensions_that_are_not_adjacent_in_any_order_still_sum_correctly() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    assert_same(
+        permuted.sum_dims(&[0, 3]),
+        one_dim_at_a_time(contiguous, &[0, 3]),
+    );
+}
+
+#[test]
+fn a_single_dimension_is_the_plain_sum_dim() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    assert_same(permuted.sum_dims(&[2]), contiguous.sum_dim(2));
+}
+
+#[test]
+fn all_dimensions_at_once_is_the_total() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    let total = permuted.sum_dims(&[0, 1, 2, 3]);
+    assert_eq!(total.dims(), [1, 1, 1, 1]);
+
+    total
+        .reshape([1])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&contiguous.sum().into_data(), Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/reduce_dims.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/reduce_dims.rs
@@ -14,10 +14,7 @@ fn permuted_and_contiguous() -> (TestTensor<4>, TestTensor<4>) {
         .float()
         .reshape([2, 4, 5, 3])
         .permute([0, 3, 1, 2]);
-    permuted.device().sync().unwrap();
-
     let contiguous = TestTensor::<4>::from_data(permuted.to_data(), &device);
-    contiguous.device().sync().unwrap();
 
     (permuted, contiguous)
 }
@@ -86,4 +83,55 @@ fn all_dimensions_at_once_is_the_total() {
         .reshape([1])
         .into_data()
         .assert_approx_eq::<FloatElem>(&contiguous.sum().into_data(), Tolerance::default());
+}
+
+#[test]
+fn a_zero_length_dimension_that_is_reduced_becomes_length_one_holding_the_identity() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::empty([0, 3], &device);
+
+    let summed = tensor.sum_dims(&[0, 1]);
+    assert_eq!(summed.dims(), [1, 1]);
+
+    summed.into_data().assert_approx_eq::<FloatElem>(
+        &TestTensor::<2>::from_data([[0.0]], &device).into_data(),
+        Tolerance::default(),
+    );
+}
+
+#[test]
+fn a_zero_length_dimension_that_is_not_reduced_leaves_the_output_empty() {
+    let tensor = TestTensor::<3>::empty([0, 2, 3], &Default::default());
+
+    let summed = tensor.sum_dims(&[1, 2]);
+
+    assert_eq!(summed.dims(), [0, 1, 1]);
+    assert_eq!(summed.into_data().num_elements(), 0);
+}
+
+#[test]
+fn a_singleton_sitting_between_two_folded_dimensions_does_not_break_the_run() {
+    let device = Default::default();
+    let contiguous = TestTensorInt::arange(0..(2 * 3 * 4), &device)
+        .float()
+        .reshape([2, 1, 3, 4]);
+
+    assert_same(
+        contiguous.clone().sum_dims(&[0, 2, 3]),
+        one_dim_at_a_time(contiguous, &[0, 2, 3]),
+    );
+}
+
+#[test]
+fn a_folded_run_of_broadcast_dimensions_counts_each_value_once_per_repeat() {
+    let device = Default::default();
+    let broadcast = TestTensor::<3>::from_data([[[1.0, 2.0, 3.0]]], &device).expand([2, 4, 3]);
+
+    let summed = broadcast.sum_dims(&[0, 1]);
+    assert_eq!(summed.dims(), [1, 1, 3]);
+
+    summed.into_data().assert_approx_eq::<FloatElem>(
+        &TestTensor::<3>::from_data([[[8.0, 16.0, 24.0]]], &device).into_data(),
+        Tolerance::default(),
+    );
 }

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -839,6 +839,26 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the sum of all elements in `tensor` along `dim`.
     fn float_sum_dim(tensor: FloatTensor<B>, dim: usize) -> FloatTensor<B>;
 
+    /// Sum the tensor along several dimensions at once, keeping each of them
+    /// with length one.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to sum.
+    /// * `dims` - The dimensions along which to sum.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same rank, and length one along each of `dims`.
+    ///
+    /// The default reduces one dimension at a time, which writes and reads
+    /// back an intermediate per dimension. A backend that can fold the
+    /// dimensions into fewer reductions should override this.
+    fn float_sum_dims(tensor: FloatTensor<B>, dims: &[usize]) -> FloatTensor<B> {
+        dims.iter()
+            .fold(tensor, |tensor, &dim| B::float_sum_dim(tensor, dim))
+    }
+
     /// Product of all elements in a tensor.
     ///
     /// # Arguments

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -7,9 +7,8 @@ use crate::{
 };
 use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type, elem_type_to_dtype};
 use burn_backend::{DType, TensorMetadata};
-use burn_std::Shape;
-use burn_std::tensor::{ReshapeAction, reshape_action};
 use burn_std::{BoolDType, Metadata};
+use burn_std::{Shape, Strides};
 use cubecl::{AutotuneKey, client::Client, features::AtomicUsage, ir::Type, prelude::InputScalar};
 use cubek::reduce::{
     ReduceDtypes, ReduceError, ReduceStrategy, ReduceWithIndicesDtypes,
@@ -194,13 +193,14 @@ pub fn reduce(
 /// a stride change alone, and reduced in a single launch — for a channels-last
 /// tensor that is every non-channel dimension at once.
 ///
-/// The folded axis is put *first* and the kept dimensions after it, so the
-/// kept innermost dimension stays innermost in memory: the reduction then
-/// coalesces across it and writes its output vectorized along it, instead of
-/// walking a strided last axis one element at a time. Where the reduced
-/// dimensions do not all sit together, the outermost is reduced on its own
-/// first; its output is contiguous, so whatever is left then folds, and no
-/// layout takes more than two launches.
+/// Only a run that memory already holds together folds, so each pass takes the
+/// largest such run and reduces that, largest first because it is the pass that
+/// leaves the least behind. The folded axis is presented *first* and the
+/// remaining dimensions after it in logical order, which puts the reduction's
+/// output back in logical order and contiguous, so the next pass starts from a
+/// tensor whose memory order is its logical one. A layout holding every reduced
+/// dimension together therefore takes a single launch, and one that scatters them
+/// takes no more launches than reducing them one at a time would have.
 pub fn reduce_dims(
     input: CubeTensor,
     output_dtype: Option<DType>,
@@ -209,63 +209,105 @@ pub fn reduce_dims(
     config: ReduceOperationConfig,
 ) -> Result<CubeTensor, ReduceError> {
     let rank = input.meta.num_dims();
-    let logical_shape = input.meta.shape().clone();
+    let mut shape = input.meta.shape().clone();
     let reduced: Vec<usize> = (0..rank).filter(|dim| dims.contains(dim)).collect();
 
-    match reduced.len() {
-        0 => return Ok(input),
-        1 => return reduce_dim(input, output_dtype, reduced[0], strategy, config),
+    // A dimension already of length one is reduced by being left alone, and its
+    // stride is arbitrary, so keeping it among the dimensions to fold would let
+    // it break a run of dimensions that do fold.
+    let mut left: Vec<usize> = reduced
+        .iter()
+        .copied()
+        .filter(|dim| shape[*dim] > 1)
+        .collect();
+
+    match (reduced.first(), left.len()) {
+        (None, _) => return Ok(input),
+        (Some(&dim), 0) => return reduce_dim(input, output_dtype, dim, strategy, config),
+        (_, 1) => return reduce_dim(input, output_dtype, left[0], strategy, config),
         _ => {}
     }
 
-    // Reduced dimensions first, outermost first so that those adjacent in
-    // memory are adjacent here too; kept dimensions after, in their own order.
-    let kept: Vec<usize> = (0..rank).filter(|dim| !dims.contains(dim)).collect();
-    let mut reduced_outermost_first = reduced.clone();
-    reduced_outermost_first.sort_by(|a, b| input.meta.strides()[*b].cmp(&input.meta.strides()[*a]));
-    let presented: Vec<usize> = reduced_outermost_first
-        .iter()
-        .chain(kept.iter())
-        .copied()
-        .collect();
-    let mut tensor = permute(input, &presented);
+    let mut tensor = input;
 
-    let mut tensor = if fold_leading_dims(&mut tensor, reduced.len()) {
-        reduce_dim(tensor, output_dtype, 0, strategy, config)?
-    } else {
-        let mut tensor = reduce_dim(tensor, output_dtype, 0, strategy.clone(), config)?;
-        // Contiguous now, so the remaining reduced dimensions all fold.
-        let folded = fold_leading_dims(&mut tensor, reduced.len());
-        debug_assert!(folded, "a contiguous tensor's leading dimensions fold");
-        reduce_dim(tensor, output_dtype, 0, strategy, config)?
-    };
+    while !left.is_empty() {
+        let run =
+            largest_run_memory_holds_together(tensor.meta.shape(), tensor.meta.strides(), &left);
+        let rest = (0..rank).filter(|dim| !run.contains(dim));
+        let presented_dims: Vec<usize> = run.iter().copied().chain(rest).collect();
 
-    // Back to the logical shape: the kept dimensions kept their order, and the
-    // reduced ones are one, so this is a stride change on a contiguous output.
-    let mut shape = logical_shape;
-    for dim in &reduced {
-        shape[*dim] = 1;
+        let mut presented = permute(tensor, &presented_dims);
+        fold_leading_dims(&mut presented, run.len());
+
+        tensor = reduce_dim(presented, output_dtype, 0, strategy.clone(), config)?;
+
+        // The reduction writes contiguously, the folded run first at length one
+        // and every other dimension after it in logical order — which is the
+        // logical shape again with the run's dimensions at length one.
+        for dim in &run {
+            shape[*dim] = 1;
+        }
+        *tensor.meta = Metadata::new(shape.clone(), burn_std::tensor::contiguous_strides(&shape));
+
+        left.retain(|dim| !run.contains(dim));
     }
-    *tensor.meta = Metadata::new(shape.clone(), burn_std::tensor::contiguous_strides(&shape));
 
     Ok(tensor)
 }
 
-/// Fold the first `count` dimensions of `tensor` into one, where its strides
-/// allow it without a copy; says whether it did.
-fn fold_leading_dims(tensor: &mut CubeTensor, count: usize) -> bool {
-    let mut folded: Vec<usize> = vec![tensor.meta.shape()[..count].iter().product()];
-    folded.extend_from_slice(&tensor.meta.shape()[count..]);
-    let folded = Shape::from(folded);
+/// The dimensions among `left` that memory already holds together — consecutive in
+/// memory order and nesting densely, so folding them into one axis is a stride
+/// change — taking the run of most elements where there is more than one.
+fn largest_run_memory_holds_together(
+    shape: &Shape,
+    strides: &Strides,
+    left: &[usize],
+) -> Vec<usize> {
+    let mut memory_order: Vec<usize> = (0..shape.num_dims()).collect();
+    memory_order.sort_by(|a, b| strides[*b].cmp(&strides[*a]).then(a.cmp(b)));
 
-    let strides = match reshape_action(tensor.meta.shape(), tensor.meta.strides(), &folded) {
-        ReshapeAction::UpdateStrides { strides } => strides,
-        ReshapeAction::NoChange => tensor.meta.strides().clone(),
-        ReshapeAction::Recompute => return false,
-    };
-    *tensor.meta = Metadata::new(folded, strides);
+    let elements = |run: &[usize]| run.iter().map(|dim| shape[*dim]).product::<usize>();
+    let mut largest: Vec<usize> = Vec::new();
+    let mut run: Vec<usize> = Vec::new();
 
-    true
+    for dim in memory_order {
+        if !left.contains(&dim) {
+            run.clear();
+            continue;
+        }
+        // A gap under the dimension outside this one leaves the two spanning more
+        // than their extents, and no stride change folds them into one axis.
+        if let Some(&outside) = run.last()
+            && strides[outside] != strides[dim] * shape[dim]
+        {
+            run.clear();
+        }
+        run.push(dim);
+
+        if elements(&run) > elements(&largest) {
+            largest.clone_from(&run);
+        }
+    }
+
+    largest
+}
+
+/// Fold the leading `count` dimensions of `tensor` into one.
+///
+/// Sound only for dimensions memory holds together, which is what
+/// [largest_run_memory_holds_together] returns: they span exactly their extents,
+/// so the axis replacing them runs at the stride of the innermost of them.
+fn fold_leading_dims(tensor: &mut CubeTensor, count: usize) {
+    let shape = tensor.meta.shape();
+    let strides = tensor.meta.strides();
+
+    let mut folded_shape: Vec<usize> = vec![shape[..count].iter().product()];
+    folded_shape.extend_from_slice(&shape[count..]);
+
+    let mut folded_strides: Vec<usize> = vec![strides[count - 1]];
+    folded_strides.extend_from_slice(&strides[count..]);
+
+    *tensor.meta = Metadata::new(Shape::from(folded_shape), Strides::new(&folded_strides));
 }
 
 /// Reduce with a logical instruction ([`Any`](ReduceOperationConfig::Any) /

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -1,11 +1,14 @@
 #[cfg(feature = "autotune")]
 use super::{autotune_reduce, autotune_reduce_with_indices, autotune_sum};
+use crate::ops::permute;
 use crate::{
     ops::numeric::{empty_device_contiguous_dtype, fill_device_dtype, zeros_client},
     tensor::CubeTensor,
 };
 use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type, elem_type_to_dtype};
 use burn_backend::{DType, TensorMetadata};
+use burn_std::Shape;
+use burn_std::tensor::{ReshapeAction, reshape_action};
 use burn_std::{BoolDType, Metadata};
 use cubecl::{AutotuneKey, client::Client, features::AtomicUsage, ir::Type, prelude::InputScalar};
 use cubek::reduce::{
@@ -180,6 +183,89 @@ pub fn reduce(
     // reshape to scalar tensor
     *tensor.meta = Metadata::new([1], [1]);
     Ok(tensor)
+}
+
+/// Reduce several `dims` of the `input` tensor with the instruction `config`,
+/// keeping each of them with length one.
+///
+/// Reducing one dimension at a time writes and reads back an intermediate per
+/// dimension, the first of which is nearly the size of the input. Dimensions
+/// that sit next to each other in memory can instead be folded into one axis by
+/// a stride change alone, and reduced in a single launch — for a channels-last
+/// tensor that is every non-channel dimension at once.
+///
+/// The folded axis is put *first* and the kept dimensions after it, so the
+/// kept innermost dimension stays innermost in memory: the reduction then
+/// coalesces across it and writes its output vectorized along it, instead of
+/// walking a strided last axis one element at a time. Where the reduced
+/// dimensions do not all sit together, the outermost is reduced on its own
+/// first; its output is contiguous, so whatever is left then folds, and no
+/// layout takes more than two launches.
+pub fn reduce_dims(
+    input: CubeTensor,
+    output_dtype: Option<DType>,
+    dims: &[usize],
+    strategy: KernelReduceStrategy,
+    config: ReduceOperationConfig,
+) -> Result<CubeTensor, ReduceError> {
+    let rank = input.meta.num_dims();
+    let logical_shape = input.meta.shape().clone();
+    let reduced: Vec<usize> = (0..rank).filter(|dim| dims.contains(dim)).collect();
+
+    match reduced.len() {
+        0 => return Ok(input),
+        1 => return reduce_dim(input, output_dtype, reduced[0], strategy, config),
+        _ => {}
+    }
+
+    // Reduced dimensions first, outermost first so that those adjacent in
+    // memory are adjacent here too; kept dimensions after, in their own order.
+    let kept: Vec<usize> = (0..rank).filter(|dim| !dims.contains(dim)).collect();
+    let mut reduced_outermost_first = reduced.clone();
+    reduced_outermost_first.sort_by(|a, b| input.meta.strides()[*b].cmp(&input.meta.strides()[*a]));
+    let presented: Vec<usize> = reduced_outermost_first
+        .iter()
+        .chain(kept.iter())
+        .copied()
+        .collect();
+    let mut tensor = permute(input, &presented);
+
+    let mut tensor = if fold_leading_dims(&mut tensor, reduced.len()) {
+        reduce_dim(tensor, output_dtype, 0, strategy, config)?
+    } else {
+        let mut tensor = reduce_dim(tensor, output_dtype, 0, strategy.clone(), config)?;
+        // Contiguous now, so the remaining reduced dimensions all fold.
+        let folded = fold_leading_dims(&mut tensor, reduced.len());
+        debug_assert!(folded, "a contiguous tensor's leading dimensions fold");
+        reduce_dim(tensor, output_dtype, 0, strategy, config)?
+    };
+
+    // Back to the logical shape: the kept dimensions kept their order, and the
+    // reduced ones are one, so this is a stride change on a contiguous output.
+    let mut shape = logical_shape;
+    for dim in &reduced {
+        shape[*dim] = 1;
+    }
+    *tensor.meta = Metadata::new(shape.clone(), burn_std::tensor::contiguous_strides(&shape));
+
+    Ok(tensor)
+}
+
+/// Fold the first `count` dimensions of `tensor` into one, where its strides
+/// allow it without a copy; says whether it did.
+fn fold_leading_dims(tensor: &mut CubeTensor, count: usize) -> bool {
+    let mut folded: Vec<usize> = vec![tensor.meta.shape()[..count].iter().product()];
+    folded.extend_from_slice(&tensor.meta.shape()[count..]);
+    let folded = Shape::from(folded);
+
+    let strides = match reshape_action(tensor.meta.shape(), tensor.meta.strides(), &folded) {
+        ReshapeAction::UpdateStrides { strides } => strides,
+        ReshapeAction::NoChange => tensor.meta.strides().clone(),
+        ReshapeAction::Recompute => return false,
+    };
+    *tensor.meta = Metadata::new(folded, strides);
+
+    true
 }
 
 /// Reduce with a logical instruction ([`Any`](ReduceOperationConfig::Any) /

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -212,6 +212,12 @@ pub fn reduce_dims(
     let mut shape = input.meta.shape().clone();
     let reduced: Vec<usize> = (0..rank).filter(|dim| dims.contains(dim)).collect();
 
+    let empty: Vec<usize> = reduced
+        .iter()
+        .copied()
+        .filter(|dim| shape[*dim] == 0)
+        .collect();
+
     // A dimension already of length one is reduced by being left alone, and its
     // stride is arbitrary, so keeping it among the dimensions to fold would let
     // it break a run of dimensions that do fold.
@@ -221,14 +227,21 @@ pub fn reduce_dims(
         .filter(|dim| shape[*dim] > 1)
         .collect();
 
-    match (reduced.first(), left.len()) {
-        (None, _) => return Ok(input),
-        (Some(&dim), 0) => return reduce_dim(input, output_dtype, dim, strategy, config),
-        (_, 1) => return reduce_dim(input, output_dtype, left[0], strategy, config),
-        _ => {}
+    if empty.is_empty() {
+        match (reduced.first(), left.len()) {
+            (None, _) => return Ok(input),
+            (Some(&dim), 0) => return reduce_dim(input, output_dtype, dim, strategy, config),
+            (_, 1) => return reduce_dim(input, output_dtype, left[0], strategy, config),
+            _ => {}
+        }
     }
 
     let mut tensor = input;
+
+    for dim in empty {
+        tensor = reduce_dim(tensor, output_dtype, dim, strategy.clone(), config)?;
+        shape[dim] = 1;
+    }
 
     while !left.is_empty() {
         let run =
@@ -271,6 +284,9 @@ fn largest_run_memory_holds_together(
     let mut run: Vec<usize> = Vec::new();
 
     for dim in memory_order {
+        if shape[dim] == 1 {
+            continue;
+        }
         if !left.contains(&dim) {
             run.clear();
             continue;

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -506,6 +506,17 @@ impl FloatTensorOps<Self> for CubeBackend {
         .unwrap()
     }
 
+    fn float_sum_dims(tensor: FloatTensor<Self>, dims: &[usize]) -> FloatTensor<Self> {
+        reduce::reduce_dims(
+            tensor,
+            None,
+            dims,
+            Default::default(),
+            ReduceOperationConfig::Sum,
+        )
+        .unwrap()
+    }
+
     fn float_mean_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         reduce::reduce_dim(
             tensor,

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -318,6 +318,10 @@ impl FloatTensorOps<Self> for Dispatch {
         B::float_sum_dim(tensor, dim)
     }
 
+    fn float_sum_dims(tensor: FloatTensor<Self>, dims: &[usize]) -> FloatTensor<Self> {
+        B::float_sum_dims(tensor, dims)
+    }
+
     fn float_mean_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         B::float_mean_dim(tensor, dim)
     }

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -1452,6 +1452,12 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_sum_dims(tensor: FloatTensor<Self>, dims: &[usize]) -> FloatTensor<Self> {
+        match dims {
+            [] => return tensor,
+            [dim] => return Self::float_sum_dim(tensor, *dim),
+            _ => {}
+        }
+
         reduce_ops!(
             @impl SumDimsOps, ReduceDimsOpIr, get_float_tensor, register_float_tensor,
             |input, desc| B::float_sum_dims(input, &desc.axes)

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -1451,6 +1451,33 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             .output()
     }
 
+    fn float_sum_dims(tensor: FloatTensor<Self>, dims: &[usize]) -> FloatTensor<Self> {
+        reduce_ops!(
+            @impl SumDimsOps, ReduceDimsOpIr, get_float_tensor, register_float_tensor,
+            |input, desc| B::float_sum_dims(input, &desc.axes)
+        );
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        // One operation for the whole reduction, so the backend underneath can
+        // fold the dimensions; issued one dimension at a time it could not.
+        let desc = ReduceDimsOpIr::create(tensor.into_ir(), dims.to_vec(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::NumericFloat(
+                    desc.out.dtype,
+                    NumericOperationIr::SumDims(desc.clone()),
+                ),
+                SumDimsOps::<B>::new(desc),
+            )
+            .output()
+    }
+
     fn float_any(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
         reduce_ops!(FloatAnyOps, float => bool, whole, |tensor, dtype| B::float_any(tensor, dtype));
 

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -1174,6 +1174,11 @@ impl RelativeOps for NumericOperationIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
             }),
+            NumericOperationIr::SumDims(desc) => NumericOperationIr::SumDims(ReduceDimsOpIr {
+                input: desc.input.to_relative(converter),
+                out: desc.out.to_relative(converter),
+                axes: desc.axes.clone(),
+            }),
             NumericOperationIr::SumDim(desc) => {
                 NumericOperationIr::SumDim(ReduceDimOpIr {
                     input: desc.input.to_relative(converter),

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -598,6 +598,8 @@ pub enum NumericOperationIr {
     /// Float => [sum dim](burn_backend::ops::FloatTensorOps::float_sum_dim).
     /// Int => [sum dim](burn_backend::ops::IntTensorOps::int_sum_dim).
     SumDim(ReduceDimOpIr),
+    /// Operation corresponding to summing several dimensions at once.
+    SumDims(ReduceDimsOpIr),
     /// Operation corresponding to:
     ///
     /// Float => [prod](burn_backend::ops::FloatTensorOps::float_prod).
@@ -1066,6 +1068,35 @@ pub struct ReduceDimOpIr {
     pub out: TensorIr,
     pub axis: usize,
     pub accumulator_len: usize,
+}
+
+/// A reduction over several dimensions at once, each kept with length one.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[allow(missing_docs)]
+pub struct ReduceDimsOpIr {
+    pub input: TensorIr,
+    pub out: TensorIr,
+    pub axes: Vec<usize>,
+}
+
+#[allow(missing_docs)]
+impl ReduceDimsOpIr {
+    pub fn create<F>(input: TensorIr, axes: Vec<usize>, mut new_id: F) -> Self
+    where
+        F: FnMut() -> crate::TensorId,
+    {
+        let mut shape = input.shape.clone();
+        for axis in &axes {
+            shape[*axis] = 1;
+        }
+        let dtype = input.dtype;
+
+        Self {
+            out: TensorIr::uninit(new_id(), shape, dtype),
+            input,
+            axes,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -2689,6 +2720,7 @@ impl NumericOperationIr {
             NumericOperationIr::Mean(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::Sum(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::SumDim(repr) => Box::new([&repr.input].into_iter()),
+            NumericOperationIr::SumDims(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::Prod(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::ProdDim(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::Max(repr) => Box::new([&repr.input].into_iter()),
@@ -2749,6 +2781,7 @@ impl NumericOperationIr {
             NumericOperationIr::Mean(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::Sum(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::SumDim(repr) => Box::new([&repr.out].into_iter()),
+            NumericOperationIr::SumDims(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::Prod(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::ProdDim(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::Max(repr) => Box::new([&repr.out].into_iter()),
@@ -2881,6 +2914,9 @@ impl NumericOperationIr {
                 repr.input.mark_read_only(nodes, &mut output);
             }
             NumericOperationIr::SumDim(repr) => {
+                repr.input.mark_read_only(nodes, &mut output);
+            }
+            NumericOperationIr::SumDims(repr) => {
                 repr.input.mark_read_only(nodes, &mut output);
             }
             NumericOperationIr::Prod(repr) => {
@@ -3100,6 +3136,10 @@ impl NumericOperationIr {
                 v.visit_tensor_mut(&mut repr.out);
             }
             NumericOperationIr::SumDim(repr) => {
+                v.visit_tensor_mut(&mut repr.input);
+                v.visit_tensor_mut(&mut repr.out);
+            }
+            NumericOperationIr::SumDims(repr) => {
                 v.visit_tensor_mut(&mut repr.input);
                 v.visit_tensor_mut(&mut repr.out);
             }

--- a/crates/burn-router/src/interpreter.rs
+++ b/crates/burn-router/src/interpreter.rs
@@ -829,6 +829,11 @@ impl<B: BackendIr> TensorInterpreter<B> {
                         tensor, axis
                     ))
                 }
+                NumericOperationIr::SumDims(desc) => {
+                    let input = handles.get_float_tensor::<B>(&desc.input);
+                    let output = B::float_sum_dims(input, &desc.axes);
+                    handles.register_float_tensor::<B>(&desc.out.id, output);
+                }
                 NumericOperationIr::Prod(desc) => {
                     unary_float_ops!(handles, desc, B::float_prod)
                 }
@@ -1070,6 +1075,14 @@ impl<B: BackendIr> TensorInterpreter<B> {
                     reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_sum_dim(
                         tensor, axis
                     ))
+                }
+                NumericOperationIr::SumDims(desc) => {
+                    let input = handles.get_int_tensor::<B>(&desc.input);
+                    let output = desc
+                        .axes
+                        .iter()
+                        .fold(input, |tensor, &axis| B::int_sum_dim(tensor, axis));
+                    handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
                 NumericOperationIr::Prod(desc) => {
                     unary_int_ops!(handles, desc, B::int_prod)

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -14,9 +14,9 @@ use burn_ir::{
     FlipOpIr, FloatOperationIr, FullOpIr, GatherNdOpIr, GatherOpIr, GridSample2dOpIr,
     InitOperationIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr, NumericOperationIr, OperationIr,
     OperationOutput, PadOpIr, PermuteOpIr, RandomOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr,
-    ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterNdOpIr, ScatterOpIr, SelectAssignOpIr,
-    SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SortOpIr, SortWithIndicesOpIr, SwapDimsOpIr,
-    TopKWithIndicesOpIr, UnaryOpIr, UnfoldOpIr,
+    ReduceDimsOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterNdOpIr, ScatterOpIr,
+    SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SortOpIr,
+    SortWithIndicesOpIr, SwapDimsOpIr, TopKWithIndicesOpIr, UnaryOpIr, UnfoldOpIr,
 };
 
 impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
@@ -725,6 +725,20 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .register(OperationIr::NumericFloat(
                 desc.out.dtype,
                 NumericOperationIr::SumDim(desc),
+            ))
+            .output()
+    }
+
+    fn float_sum_dims(tensor: FloatTensor<Self>, dims: &[usize]) -> FloatTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = ReduceDimsOpIr::create(tensor.into_ir(), dims.to_vec(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::NumericFloat(
+                desc.out.dtype,
+                NumericOperationIr::SumDims(desc),
             ))
             .output()
     }

--- a/crates/burn-tensor/src/bridge/ops/float.rs
+++ b/crates/burn-tensor/src/bridge/ops/float.rs
@@ -500,6 +500,20 @@ impl Numeric for Float {
         }
     }
 
+    fn sum_dims(tensor: BridgeTensor, dims: &[usize]) -> BridgeTensor {
+        let (kind, tensor) = tensor.into_parts();
+        match kind {
+            BridgeKind::Float => BridgeTensor::float(Dispatch::float_sum_dims(tensor, dims)),
+            // Quantized reductions have no multi-dimension form; one at a time.
+            BridgeKind::QFloat => dims
+                .iter()
+                .fold(BridgeTensor::qfloat(tensor), |tensor, &dim| {
+                    Self::sum_dim(tensor, dim)
+                }),
+            _ => panic!("Should be Float primitive kind"),
+        }
+    }
+
     fn prod(tensor: BridgeTensor) -> BridgeTensor {
         let (kind, tensor) = tensor.into_parts();
         match kind {

--- a/crates/burn-tensor/src/bridge/ops/int.rs
+++ b/crates/burn-tensor/src/bridge/ops/int.rs
@@ -282,6 +282,11 @@ impl Numeric for Int {
         BridgeTensor::int(Dispatch::int_sum_dim(tensor.into(), dim))
     }
 
+    fn sum_dims(tensor: BridgeTensor, dims: &[usize]) -> BridgeTensor {
+        dims.iter()
+            .fold(tensor, |tensor, &dim| Self::sum_dim(tensor, dim))
+    }
+
     fn prod(tensor: BridgeTensor) -> BridgeTensor {
         BridgeTensor::int(Dispatch::int_prod(tensor.into()))
     }

--- a/crates/burn-tensor/src/bridge/ops/numeric.rs
+++ b/crates/burn-tensor/src/bridge/ops/numeric.rs
@@ -302,6 +302,12 @@ pub(crate) trait Numeric: BasicOps {
     /// function, which is more high-level and designed for public use.
     fn sum_dim(tensor: BridgeTensor, dim: usize) -> BridgeTensor;
 
+    /// Sums the elements of the tensor along several dimensions at once.
+    ///
+    /// Users should prefer the [`Tensor::sum_dims`](crate::Tensor::sum_dims) function, which is
+    /// more high-level and designed for public use.
+    fn sum_dims(tensor: BridgeTensor, dims: &[usize]) -> BridgeTensor;
+
     /// Computes the product of all the elements of the tensor.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1,5 +1,7 @@
 use burn_backend::Scalar;
 
+use alloc::vec::Vec;
+
 use crate::alloc::borrow::ToOwned;
 use crate::check::unwrap_dim_index;
 use crate::kind::Numeric;

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -426,7 +426,11 @@ where
     /// // [[27]]
     /// ```
     pub fn sum_dims<I: AsIndex>(self, dims: &[I]) -> Self {
-        dims.iter().fold(self, |tensor, &dim| tensor.sum_dim(dim))
+        let dims: Vec<usize> = dims
+            .iter()
+            .map(|&dim| unwrap_dim_index(dim.try_dim_index(D), "Sum Dims"))
+            .collect();
+        Self::new(K::sum_dims(self.primitive, &dims))
     }
 
     /// Aggregate and squeeze along the given dimensions.


### PR DESCRIPTION
### Changes

Adds `FloatTensorOps::float_sum_dims` to sum several dimensions while keeping each reduced dimension at length one. The default implementation reduces one dimension at a time, preserving compatibility with existing backends.

Broadcast-gradient reduction and `Tensor::sum_dims` now use this operation. Fusion and Router preserve multi-axis requests as `NumericOperationIr::SumDims`, allowing the underlying backend to optimize them together. Fusion forwards single-axis requests to the existing `SumDim` path.

CubeCL folds reduced dimensions that are densely adjacent in memory into one axis using metadata changes, then reduces that axis. Each pass selects the largest foldable group and produces a contiguous output before processing the remaining dimensions.

For dense channels-last activations, batch and spatial dimensions can fold into one reduction. For contiguous NCHW tensors, height and width fold together, followed by batch reduction. Other layouts may require additional passes, up to one per requested dimension. Singleton dimensions do not split foldable groups, and empty reduction axes retain the existing sum-identity behavior.

Multi-axis reduction fusion with surrounding elementwise operations is deferred to a separate PR.

Measured on CUDA (one L4), same session, warm, first pass discarded, median of twenty, on a convolutional classifier with channels-last activations: a training step went from 369.7 ms to 362.0 ms; reduce launches per step fell by 40% and the time spent in them by 30% (115 ms to 80 ms), most of which had been overlapped with other work. The forward pass, which does not reach this path, was unchanged.

### Testing

Nine tests compare multi-axis sums with sequential reductions or explicit expected values, covering:

- Channels-last and contiguous layouts.
- Nonadjacent reduction axes.
- Single-axis and all-axis reductions.
- Reduced and unreduced zero-length dimensions.
- Singleton dimensions between foldable axes.
- Broadcast dimensions with repeated values.

### Reproduction

https://github.com/Marc-AnthonyG/burn-reproduction/tree/main/cases/sum-dims-single-reduction

Run with `cargo run --release -p sum-dims-single-reduction --features cuda`.

# METAL
<img width="1180" height="446" alt="Screenshot 2026-09-08 at 2 34 37 PM" src="https://github.com/user-attachments/assets/c6824ea4-3571-47ad-89e7-f3dc670750a2" />

# CUDA
<img width="1102" height="219" alt="Screenshot 2026-09-08 at 3 20 44 PM" src="https://github.com/user-attachments/assets/a16009ed-392d-43c9-ada6-9e933c56e33e" />

