### PR TITLE
perf(cubecl): walk elementwise kernels in operands' memory order

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -105,6 +105,7 @@ mod negative_dims;
 mod one_hot;
 mod padding;
 mod permute;
+mod permuted_operands;
 mod powf;
 mod powf_scalar;
 mod prod;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/permuted_operands.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/permuted_operands.rs
@@ -6,7 +6,7 @@
 //! changes what it computes.
 
 use super::*;
-use burn_tensor::Tolerance;
+use burn_tensor::{TensorData, Tolerance};
 
 /// A `[2, 3, 4, 5]` tensor held channels-last in memory, and a contiguous copy
 /// of the same values.
@@ -14,6 +14,7 @@ fn permuted_and_contiguous() -> (TestTensor<4>, TestTensor<4>) {
     let device = Default::default();
     let permuted = TestTensorInt::arange(0..(2 * 3 * 4 * 5), &device)
         .float()
+        .div_scalar(120.0)
         .reshape([2, 4, 5, 3])
         .permute([0, 3, 1, 2]);
     let contiguous = TestTensor::<4>::from_data(permuted.to_data(), &device);
@@ -21,7 +22,7 @@ fn permuted_and_contiguous() -> (TestTensor<4>, TestTensor<4>) {
     (permuted, contiguous)
 }
 
-fn assert_same(permuted: TestTensor<4>, contiguous: TestTensor<4>) {
+fn assert_same<const D: usize>(permuted: TestTensor<D>, contiguous: TestTensor<D>) {
     let expected = contiguous.into_data();
     let actual = permuted.into_data();
 
@@ -84,4 +85,127 @@ fn unary_on_a_permuted_operand_matches_the_contiguous_answer() {
     let (permuted, contiguous) = permuted_and_contiguous();
 
     assert_same(permuted.exp(), contiguous.exp());
+}
+
+#[test]
+fn expanded_singleton_keeps_the_contiguous_answer() {
+    let device = Default::default();
+    let tensor = TestTensorInt::arange(0..1024, &device).float();
+    let expanded = tensor.expand([1, 1024]);
+    let contiguous = TestTensor::<2>::from_data(expanded.to_data(), &device);
+    assert_same(
+        expanded.clone().mul_scalar(2.5),
+        contiguous.clone().mul_scalar(2.5),
+    );
+    assert_same(expanded.clone().abs(), contiguous.clone().abs());
+    assert_same(expanded.clone() + expanded, contiguous.clone() + contiguous);
+}
+
+#[test]
+fn two_different_nonlogical_layouts_match_in_both_operand_orders() {
+    let device = Default::default();
+    let values = TestTensorInt::arange(0..24, &device).float();
+    let left = values.clone().reshape([2, 4, 3]).permute([0, 2, 1]);
+    let right = values.reshape([3, 2, 4]).permute([1, 0, 2]);
+    let left_contiguous = TestTensor::<3>::from_data(left.to_data(), &device);
+    let right_contiguous = TestTensor::<3>::from_data(right.to_data(), &device);
+    assert_same(
+        left.clone() - right.clone(),
+        left_contiguous.clone() - right_contiguous.clone(),
+    );
+    assert_same(right - left, right_contiguous - left_contiguous);
+}
+
+#[test]
+fn padded_channels_last_operands_match_for_each_launcher() {
+    let device = Default::default();
+    // Keep eight of twelve channels: vectorizable rows with padding between them.
+    let tensor = TestTensorInt::arange(0..(2 * 4 * 5 * 12), &device)
+        .float()
+        .div_scalar(480.0)
+        .reshape([2, 4, 5, 12])
+        .slice([0..2, 0..4, 0..5, 0..8])
+        .permute([0, 3, 1, 2]);
+    let contiguous = TestTensor::<4>::from_data(tensor.to_data(), &device);
+    assert_same(
+        tensor.clone() * tensor.clone(),
+        contiguous.clone() * contiguous.clone(),
+    );
+    assert_same(
+        tensor.clone().powf(tensor.clone()),
+        contiguous.clone().powf(contiguous.clone()),
+    );
+    assert_same(
+        tensor.clone().mul_scalar(2.5),
+        contiguous.clone().mul_scalar(2.5),
+    );
+    assert_same(tensor.clone().exp(), contiguous.clone().exp());
+    assert_same(tensor.abs(), contiguous.abs());
+}
+
+#[test]
+fn large_spatial_broadcast_matches_the_contiguous_answer() {
+    let device = Default::default();
+    let tensor = TestTensorInt::arange(0..(2 * 8 * 16 * 16), &device)
+        .float()
+        .reshape([2, 16, 16, 8])
+        .permute([0, 3, 1, 2]);
+    let spatial = TestTensorInt::arange(0..(16 * 16), &device)
+        .float()
+        .reshape([1, 1, 16, 16]);
+    let contiguous = TestTensor::<4>::from_data(tensor.to_data(), &device);
+    assert_same(tensor * spatial.clone(), contiguous * spatial);
+}
+
+#[test]
+fn fresh_elementwise_outputs_can_be_flattened_in_logical_order() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+    // Retain both inputs so every operation must allocate an output. Flattening
+    // must preserve NCHW value order, independent of the input's physical layout.
+    assert_same(
+        permuted.clone().mul_scalar(2.5).reshape([120]),
+        contiguous.clone().mul_scalar(2.5).reshape([120]),
+    );
+    assert_same(
+        (permuted.clone() * permuted.clone()).reshape([2, 60]),
+        (contiguous.clone() * contiguous.clone()).reshape([2, 60]),
+    );
+    assert_same(
+        permuted.clone().exp().reshape([120]),
+        contiguous.clone().exp().reshape([120]),
+    );
+    assert_same(
+        permuted.clone().abs().reshape([120]),
+        contiguous.clone().abs().reshape([120]),
+    );
+    assert_same(
+        permuted.clone().atan2(permuted.clone()).reshape([120]),
+        contiguous.clone().atan2(contiguous.clone()).reshape([120]),
+    );
+}
+
+#[test]
+fn binary_reusing_the_right_operand_preserves_value_order() {
+    let (left, left_contiguous) = permuted_and_contiguous();
+    let (right, right_contiguous) = permuted_and_contiguous();
+    // Only the right input may be overwritten. Subtraction checks operand order
+    // as well as the inverse permutation applied to the reused result.
+    let right = right.mul_scalar(2.0);
+    let right_contiguous = right_contiguous.mul_scalar(2.0);
+    assert_same(
+        (left.clone() - right).reshape([120]),
+        (left_contiguous.clone() - right_contiguous).reshape([120]),
+    );
+}
+
+#[test]
+fn empty_binary_outputs_bypass_buffer_reuse_checks() {
+    let device = Default::default();
+    let empty = TestTensor::<2>::from_data(TensorData::new(Vec::<f32>::new(), [0, 8]), &device);
+    let row = TestTensor::<2>::ones([1, 8], &device);
+    assert_eq!(
+        (empty.clone() + row.clone()).into_data().shape.as_slice(),
+        &[0, 8]
+    );
+    assert_eq!(empty.atan2(row).into_data().shape.as_slice(), &[0, 8]);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/permuted_operands.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/permuted_operands.rs
@@ -1,0 +1,87 @@
+//! The elementwise kernels on an operand that is not in logical dimension
+//! order — a channels-last tensor presented in NCHW, as a convolution hands
+//! one on. Each case runs the same operation on a contiguous copy and asks for
+//! the same answer, so nothing here depends on a hand-computed expectation:
+//! what is pinned is that the walk order a kernel picks for its operands never
+//! changes what it computes.
+
+use super::*;
+use burn_tensor::Tolerance;
+
+/// A `[2, 3, 4, 5]` tensor held channels-last in memory, and a contiguous copy
+/// of the same values.
+fn permuted_and_contiguous() -> (TestTensor<4>, TestTensor<4>) {
+    let device = Default::default();
+    let permuted = TestTensorInt::arange(0..(2 * 3 * 4 * 5), &device)
+        .float()
+        .reshape([2, 4, 5, 3])
+        .permute([0, 3, 1, 2]);
+    let contiguous = TestTensor::<4>::from_data(permuted.to_data(), &device);
+
+    (permuted, contiguous)
+}
+
+fn assert_same(permuted: TestTensor<4>, contiguous: TestTensor<4>) {
+    let expected = contiguous.into_data();
+    let actual = permuted.into_data();
+
+    assert_eq!(actual.shape, expected.shape);
+    actual.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn binary_with_both_operands_alive_matches_the_contiguous_answer() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    // Both operands stay alive, so the kernel writes a fresh output.
+    assert_same(
+        permuted.clone() * permuted.clone(),
+        contiguous.clone() * contiguous.clone(),
+    );
+}
+
+#[test]
+fn binary_consuming_a_permuted_operand_matches_the_contiguous_answer() {
+    let (left, contiguous) = permuted_and_contiguous();
+    let (right, _) = permuted_and_contiguous();
+
+    // Each operand owns its buffer and is consumed, so the kernel may write
+    // over one of them in place; a clone would share the buffer and rule that
+    // out.
+    assert_same(left + right, contiguous.clone() + contiguous);
+}
+
+#[test]
+fn binary_with_a_broadcast_operand_matches_the_contiguous_answer() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+    let device = permuted.device();
+    let per_channel = TestTensor::<4>::from_data([[[[1.5]], [[-2.0]], [[0.25]]]], &device);
+
+    assert_same(permuted * per_channel.clone(), contiguous * per_channel);
+}
+
+#[test]
+fn a_permuted_and_a_contiguous_operand_together_match_the_contiguous_answer() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    // The two operands disagree on their memory order; whichever walk the
+    // kernel picks, one of them is read strided and the answer is the same.
+    assert_same(
+        permuted - contiguous.clone(),
+        contiguous.clone() - contiguous,
+    );
+}
+
+#[test]
+fn scalar_on_a_permuted_operand_matches_the_contiguous_answer() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    assert_same(permuted.mul_scalar(2.5), contiguous.mul_scalar(2.5));
+}
+
+#[test]
+fn unary_on_a_permuted_operand_matches_the_contiguous_answer() {
+    let (permuted, contiguous) = permuted_and_contiguous();
+
+    assert_same(permuted.exp(), contiguous.exp());
+}

--- a/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
@@ -17,86 +17,9 @@
 //! order. So the layout is free to choose, and the cost of a choice is the
 //! traffic of the inputs that disagree with it.
 
-use burn_std::{Shape, Strides};
+use burn_std::Strides;
 
-/// The order a tensor's dimensions appear in memory, outermost first.
-///
-/// `[0, 1, 2, 3]` is contiguous NCHW; `[0, 2, 3, 1]` is NHWC. This is the same
-/// convention as the permutation passed to `Tensor::permute`.
-pub type DimOrder = Shape;
-
-/// The dimension order of a tensor that is dense in memory, or `None` if it is
-/// not dense.
-///
-/// Dense means the strides are exactly a permutation of contiguous strides: no
-/// gaps, no overlap, no broadcasting. Use [nested_dim_order] when only an
-/// iteration order is needed and gaps in storage are acceptable.
-///
-/// Dimensions of size one are ignored while checking density — their stride is
-/// arbitrary and carries no traffic — but they keep a position in the returned
-/// order so it stays a permutation of `0..rank`.
-pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
-    dim_order_inner(shape, strides, Padding::Rejected)
-}
-
-/// The dimension order of a tensor whose dimensions nest without overlapping,
-/// or `None` if they do not.
-///
-/// Weaker than [dim_order], which additionally requires consecutive elements
-/// without gaps. A dimension may sit at a larger stride than the extents inside it
-/// need, which is what a pitched or tile-aligned allocation produces: 48
-/// channels held innermost on a 64-element tile have stride 64 where a dense
-/// tensor would have 48.
-///
-/// Iterating in this order can improve locality, but reads must still use the
-/// tensor's actual strides. Gaps can affect memory transactions and vectorization;
-/// accepting an order does not guarantee dense-access performance. This also
-/// accepts sliced views whose dimensions satisfy the same nesting condition.
-/// Anything reinterpreting a buffer as a flat run of elements must keep asking
-/// [dim_order].
-pub fn nested_dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
-    dim_order_inner(shape, strides, Padding::Allowed)
-}
-
-#[derive(Clone, Copy)]
-enum Padding {
-    Allowed,
-    Rejected,
-}
-
-fn dim_order_inner(shape: &[usize], strides: &[usize], padding: Padding) -> Option<DimOrder> {
-    let rank = shape.len();
-
-    if rank != strides.len() {
-        return None;
-    }
-
-    let mut order: Vec<usize> = (0..rank).collect();
-    // Descending stride is outermost first. The dimension index breaks ties so
-    // that equal strides — which only happens among size-one dimensions — give
-    // a deterministic order rather than one that depends on the sort.
-    order.sort_by(|a, b| strides[*b].cmp(&strides[*a]).then(a.cmp(b)));
-
-    let mut expected = 1;
-
-    for &axis in order.iter().rev() {
-        if shape[axis] == 1 {
-            continue;
-        }
-        match padding {
-            // A gap is what makes the tensor padded rather than dense; an
-            // overlap is not a layout at all.
-            Padding::Allowed if strides[axis] < expected => return None,
-            Padding::Rejected if strides[axis] != expected => return None,
-            _ => {}
-        }
-        // Where the stride is exactly `expected` this is `expected *= shape[axis]`,
-        // so the dense walk is the padded one with the gaps taken out.
-        expected = strides[axis] * shape[axis];
-    }
-
-    Some(Shape::from(order))
-}
+pub use burn_std::tensor::layout::{DimOrder, dim_order, is_contiguous_order, nested_dim_order};
 
 /// The axis a vector runs along in a tensor laid out in a permuted order, or
 /// `None` when the tensor is in logical dimension order, is not dense, or has no
@@ -146,64 +69,10 @@ pub fn strides_for(shape: &[usize], order: &[usize]) -> Strides {
     Strides::new(&strides)
 }
 
-/// Whether a dimension order is the contiguous one, `[0, 1, .., rank - 1]`.
-pub fn is_contiguous_order(order: &[usize]) -> bool {
-    order.iter().enumerate().all(|(pos, axis)| pos == *axis)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn contiguous_is_the_identity_order() {
-        let shape = [2, 48, 16, 16];
-        let strides = [48 * 16 * 16, 16 * 16, 16, 1];
-
-        assert_eq!(
-            dim_order(&shape, &strides),
-            Some(Shape::from(vec![0, 1, 2, 3]))
-        );
-    }
-
-    #[test]
-    fn nhwc_memory_gives_the_nhwc_order() {
-        // What a convolution hands its successor: shape is NCHW, memory is NHWC.
-        let shape = [2, 48, 16, 16];
-        let strides = [16 * 16 * 48, 1, 16 * 48, 48];
-
-        assert_eq!(
-            dim_order(&shape, &strides),
-            Some(Shape::from(vec![0, 2, 3, 1]))
-        );
-    }
-
-    #[test]
-    fn broadcast_is_not_dense() {
-        let shape = [2, 48, 16, 16];
-        let strides = [0, 1, 0, 0];
-
-        assert_eq!(dim_order(&shape, &strides), None);
-    }
-
-    #[test]
-    fn a_slice_is_not_dense() {
-        // A view into a wider tensor: the row stride overshoots the row.
-        let shape = [4, 8];
-        let strides = [16, 1];
-
-        assert_eq!(dim_order(&shape, &strides), None);
-    }
-
-    #[test]
-    fn size_one_dimensions_do_not_decide_density() {
-        // A per-channel parameter presented at full rank. The strides of the
-        // degenerate dimensions say nothing, and must not make it non-dense.
-        let shape = [1, 48, 1, 1];
-        let strides = [48, 1, 48, 48];
-
-        assert!(dim_order(&shape, &strides).is_some());
-    }
+    use burn_std::Shape;
 
     #[test]
     fn round_trips_through_strides() {
@@ -216,17 +85,6 @@ mod tests {
             dim_order(&shape, &strides),
             Some(Shape::from(order.to_vec()))
         );
-    }
-
-    #[test]
-    fn the_order_ends_at_the_innermost_dimension() {
-        let shape = [2, 48, 16, 16];
-
-        let contiguous = dim_order(&shape, &[48 * 16 * 16, 16 * 16, 16, 1]).unwrap();
-        let nhwc = dim_order(&shape, &[16 * 16 * 48, 1, 16 * 48, 48]).unwrap();
-
-        assert_eq!(contiguous.last(), Some(&3));
-        assert_eq!(nhwc.last(), Some(&1));
     }
 
     #[test]
@@ -292,78 +150,5 @@ mod tests {
     #[test]
     fn a_single_element_tensor_asks_for_nothing() {
         assert_eq!(permuted_innermost_axis(&[1, 1, 1, 1], &[1, 1, 1, 1]), None);
-    }
-
-    #[test]
-    fn order_is_a_permutation() {
-        assert!(is_contiguous_order(&[0, 1, 2, 3]));
-        assert!(!is_contiguous_order(&[0, 2, 3, 1]));
-    }
-
-    #[test]
-    fn a_dense_tensor_nests_in_the_order_it_is_dense_in() {
-        let shape = [2, 48, 16, 16];
-
-        for strides in [
-            [48 * 16 * 16, 16 * 16, 16, 1],
-            [16 * 16 * 48, 1, 16 * 48, 48],
-        ] {
-            let dense = dim_order(&shape, &strides);
-            assert!(dense.is_some());
-            assert_eq!(nested_dim_order(&shape, &strides), dense);
-        }
-    }
-
-    #[test]
-    fn padding_under_the_innermost_dimension_keeps_the_nhwc_order() {
-        let shape = [2, 48, 16, 16];
-        let strides = [16 * 16 * 64, 1, 16 * 64, 64];
-
-        assert_eq!(dim_order(&shape, &strides), None);
-        assert_eq!(
-            nested_dim_order(&shape, &strides),
-            Some(Shape::from(vec![0, 2, 3, 1]))
-        );
-    }
-
-    #[test]
-    fn padding_above_the_innermost_dimension_is_nesting_too() {
-        let shape = [4, 8];
-        let strides = [16, 1];
-
-        assert_eq!(dim_order(&shape, &strides), None);
-        assert_eq!(
-            nested_dim_order(&shape, &strides),
-            Some(Shape::from(vec![0, 1]))
-        );
-    }
-
-    #[test]
-    fn overlapping_dimensions_are_not_an_order_under_either() {
-        let shape = [4, 8];
-        let strides = [4, 1];
-
-        assert_eq!(dim_order(&shape, &strides), None);
-        assert_eq!(nested_dim_order(&shape, &strides), None);
-    }
-
-    #[test]
-    fn a_broadcast_dimension_still_cannot_vote() {
-        let shape = [2, 48, 16, 16];
-        let strides = [0, 1, 0, 0];
-
-        assert_eq!(nested_dim_order(&shape, &strides), None);
-    }
-
-    #[test]
-    fn size_one_dimensions_neither_pad_nor_constrain_nesting() {
-        let shape = [1, 48, 1, 1];
-        let strides = [48, 1, 48, 48];
-
-        assert_eq!(
-            nested_dim_order(&shape, &strides),
-            dim_order(&shape, &strides)
-        );
-        assert!(nested_dim_order(&shape, &strides).is_some());
     }
 }

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -225,12 +225,11 @@ pub(crate) fn kernel_binop<C: Numeric, N: Size, O: BinaryOpFamily>(
 
 pub(crate) fn launch_binop<O: BinaryOpFamily>(lhs: CubeTensor, rhs: CubeTensor) -> CubeTensor {
     let output_shape = broadcast_shape(&[&lhs, &rhs]);
-    in_memory_order([lhs, rhs], &output_shape, |[lhs, rhs]| {
+    in_memory_order([lhs, rhs], output_shape, |[lhs, rhs], shape_out| {
         let vector_size_lhs = max_vector_size(&lhs);
         let vector_size_rhs = max_vector_size(&rhs);
         let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
 
-        let shape_out = broadcast_shape(&[&lhs, &rhs]);
         let dtype = lhs.dtype;
 
         // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
@@ -302,7 +301,7 @@ pub(crate) fn launch_scalar_binop<O: BinaryOpFamily>(
     scalar: InputScalar,
 ) -> CubeTensor {
     let output_shape = tensor.shape();
-    in_memory_order([tensor], &output_shape, |[tensor]| {
+    in_memory_order([tensor], output_shape, |[tensor], shape_out| {
         // Vectorization is only enabled when the last dimension is contiguous.
         let vector_size = max_vector_size(&tensor);
         let client = tensor.client.clone();
@@ -332,7 +331,7 @@ pub(crate) fn launch_scalar_binop<O: BinaryOpFamily>(
                 let output = empty_device_dtype(
                     tensor.client.clone(),
                     tensor.device.clone(),
-                    tensor.shape(),
+                    shape_out,
                     dtype,
                 );
 

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -1,3 +1,4 @@
+use crate::kernel::memory_order::in_memory_order;
 use crate::{
     kernel::utils::{address_type, broadcast_shape},
     ops::{max_vector_size, numeric::empty_device_dtype},
@@ -223,126 +224,132 @@ pub(crate) fn kernel_binop<C: Numeric, N: Size, O: BinaryOpFamily>(
 }
 
 pub(crate) fn launch_binop<O: BinaryOpFamily>(lhs: CubeTensor, rhs: CubeTensor) -> CubeTensor {
-    let vector_size_lhs = max_vector_size(&lhs);
-    let vector_size_rhs = max_vector_size(&rhs);
-    let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
+    let output_shape = broadcast_shape(&[&lhs, &rhs]);
+    in_memory_order([lhs, rhs], &output_shape, |[lhs, rhs]| {
+        let vector_size_lhs = max_vector_size(&lhs);
+        let vector_size_rhs = max_vector_size(&rhs);
+        let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
 
-    let shape_out = broadcast_shape(&[&lhs, &rhs]);
-    let dtype = lhs.dtype;
+        let shape_out = broadcast_shape(&[&lhs, &rhs]);
+        let dtype = lhs.dtype;
 
-    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
-    // below assume a non-empty output. Return the empty output directly.
-    if shape_out.num_elements() == 0 {
-        return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
-    }
-
-    let client = lhs.client.clone();
-    let num_elems = shape_out.num_elements();
-    let working_units = num_elems / vector_size as usize;
-
-    let cube_dim = CubeDim::new(&lhs.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&lhs.client, working_units, cube_dim);
-
-    unsafe {
-        if lhs.can_mut_broadcast(&rhs) {
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs),
-                vector_size,
-                lhs.clone().into_linear_view(),
-                rhs.into_linear_view_like(&lhs),
-                lhs.as_linear_view_alias(0),
-                dtype_to_storage_type(dtype),
-            );
-
-            lhs
-        } else if rhs.can_mut_broadcast(&lhs) {
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs),
-                vector_size,
-                lhs.into_linear_view_like(&rhs),
-                rhs.clone().into_linear_view(),
-                rhs.as_linear_view_alias(1),
-                dtype_to_storage_type(dtype),
-            );
-
-            rhs
-        } else {
-            let output =
-                empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
-
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs, output),
-                vector_size,
-                lhs.into_linear_view_like(&output),
-                rhs.into_linear_view_like(&output),
-                output.clone().into_linear_view(),
-                dtype_to_storage_type(dtype),
-            );
-
-            output
+        // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+        // below assume a non-empty output. Return the empty output directly.
+        if shape_out.num_elements() == 0 {
+            return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
         }
-    }
+
+        let client = lhs.client.clone();
+        let num_elems = shape_out.num_elements();
+        let working_units = num_elems / vector_size as usize;
+
+        let cube_dim = CubeDim::new(&lhs.client, working_units);
+        let cube_count = calculate_cube_count_elemwise(&lhs.client, working_units, cube_dim);
+
+        unsafe {
+            if lhs.can_mut_broadcast(&rhs) {
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs),
+                    vector_size,
+                    lhs.clone().into_linear_view(),
+                    rhs.into_linear_view_like(&lhs),
+                    lhs.as_linear_view_alias(0),
+                    dtype_to_storage_type(dtype),
+                );
+
+                lhs
+            } else if rhs.can_mut_broadcast(&lhs) {
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs),
+                    vector_size,
+                    lhs.into_linear_view_like(&rhs),
+                    rhs.clone().into_linear_view(),
+                    rhs.as_linear_view_alias(1),
+                    dtype_to_storage_type(dtype),
+                );
+
+                rhs
+            } else {
+                let output =
+                    empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
+
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs, output),
+                    vector_size,
+                    lhs.into_linear_view_like(&output),
+                    rhs.into_linear_view_like(&output),
+                    output.clone().into_linear_view(),
+                    dtype_to_storage_type(dtype),
+                );
+
+                output
+            }
+        }
+    })
 }
 
 pub(crate) fn launch_scalar_binop<O: BinaryOpFamily>(
     tensor: CubeTensor,
     scalar: InputScalar,
 ) -> CubeTensor {
-    // Vectorization is only enabled when the last dimension is contiguous.
-    let vector_size = max_vector_size(&tensor);
-    let client = tensor.client.clone();
-    let num_elems = tensor.meta.num_elements();
-    let dtype = tensor.dtype;
+    let output_shape = tensor.shape();
+    in_memory_order([tensor], &output_shape, |[tensor]| {
+        // Vectorization is only enabled when the last dimension is contiguous.
+        let vector_size = max_vector_size(&tensor);
+        let client = tensor.client.clone();
+        let num_elems = tensor.meta.num_elements();
+        let dtype = tensor.dtype;
 
-    let working_units = num_elems / vector_size as usize;
-    let cube_dim = CubeDim::new(&tensor.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
+        let working_units = num_elems / vector_size as usize;
+        let cube_dim = CubeDim::new(&tensor.client, working_units);
+        let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
 
-    unsafe {
-        if tensor.can_mut() && tensor.is_nonoverlapping() {
-            kernel_scalar_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor),
-                vector_size,
-                tensor.clone().into_linear_view(),
-                scalar,
-                tensor.as_linear_view_alias(0),
-                dtype_to_storage_type(dtype),
-            );
+        unsafe {
+            if tensor.can_mut() && tensor.is_nonoverlapping() {
+                kernel_scalar_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor),
+                    vector_size,
+                    tensor.clone().into_linear_view(),
+                    scalar,
+                    tensor.as_linear_view_alias(0),
+                    dtype_to_storage_type(dtype),
+                );
 
-            tensor
-        } else {
-            let output = empty_device_dtype(
-                tensor.client.clone(),
-                tensor.device.clone(),
-                tensor.shape(),
-                dtype,
-            );
+                tensor
+            } else {
+                let output = empty_device_dtype(
+                    tensor.client.clone(),
+                    tensor.device.clone(),
+                    tensor.shape(),
+                    dtype,
+                );
 
-            kernel_scalar_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor, output),
-                vector_size,
-                tensor.into_linear_view(),
-                scalar,
-                output.clone().into_linear_view(),
-                dtype_to_storage_type(dtype),
-            );
+                kernel_scalar_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor, output),
+                    vector_size,
+                    tensor.into_linear_view(),
+                    scalar,
+                    output.clone().into_linear_view(),
+                    dtype_to_storage_type(dtype),
+                );
 
-            output
+                output
+            }
         }
-    }
+    })
 }

--- a/crates/burn-cubecl/src/kernel/binary_float.rs
+++ b/crates/burn-cubecl/src/kernel/binary_float.rs
@@ -55,12 +55,11 @@ pub(crate) fn launch_binop_float<O: BinaryOpFloatFamily>(
     rhs: CubeTensor,
 ) -> CubeTensor {
     let output_shape = broadcast_shape(&[&lhs, &rhs]);
-    in_memory_order([lhs, rhs], &output_shape, |[lhs, rhs]| {
+    in_memory_order([lhs, rhs], output_shape, |[lhs, rhs], shape_out| {
         let vector_size_lhs = max_vector_size(&lhs);
         let vector_size_rhs = max_vector_size(&rhs);
         let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
 
-        let shape_out = broadcast_shape(&[&lhs, &rhs]);
         let dtype = lhs.dtype;
 
         // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths

--- a/crates/burn-cubecl/src/kernel/binary_float.rs
+++ b/crates/burn-cubecl/src/kernel/binary_float.rs
@@ -1,3 +1,4 @@
+use crate::kernel::memory_order::in_memory_order;
 use crate::{
     kernel::utils::{address_type, broadcast_shape},
     ops::{max_vector_size, numeric::empty_device_dtype},
@@ -53,74 +54,77 @@ pub(crate) fn launch_binop_float<O: BinaryOpFloatFamily>(
     lhs: CubeTensor,
     rhs: CubeTensor,
 ) -> CubeTensor {
-    let vector_size_lhs = max_vector_size(&lhs);
-    let vector_size_rhs = max_vector_size(&rhs);
-    let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
+    let output_shape = broadcast_shape(&[&lhs, &rhs]);
+    in_memory_order([lhs, rhs], &output_shape, |[lhs, rhs]| {
+        let vector_size_lhs = max_vector_size(&lhs);
+        let vector_size_rhs = max_vector_size(&rhs);
+        let vector_size = Ord::min(vector_size_lhs, vector_size_rhs);
 
-    let shape_out = broadcast_shape(&[&lhs, &rhs]);
-    let dtype = lhs.dtype;
+        let shape_out = broadcast_shape(&[&lhs, &rhs]);
+        let dtype = lhs.dtype;
 
-    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
-    // below assume a non-empty output. Return the empty output directly.
-    if shape_out.num_elements() == 0 {
-        return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
-    }
-
-    let client = lhs.client.clone();
-    let num_elems = shape_out.num_elements();
-    let working_units = num_elems / vector_size as usize;
-
-    let cube_dim = CubeDim::new(&lhs.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&lhs.client, working_units, cube_dim);
-
-    unsafe {
-        if lhs.can_mut_broadcast(&rhs) {
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs),
-                vector_size,
-                lhs.clone().into_linear_view(),
-                rhs.clone().into_linear_view_like(&lhs),
-                lhs.as_linear_view_alias(0),
-                dtype_to_storage_type(dtype),
-            );
-
-            lhs
-        } else if rhs.can_mut_broadcast(&lhs) {
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs),
-                vector_size,
-                lhs.into_linear_view_like(&rhs),
-                rhs.clone().into_linear_view(),
-                rhs.as_linear_view_alias(1),
-                dtype_to_storage_type(dtype),
-            );
-
-            rhs
-        } else {
-            let output =
-                empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
-
-            kernel_binop::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(lhs, rhs, output),
-                vector_size,
-                lhs.into_linear_view_like(&output),
-                rhs.into_linear_view_like(&output),
-                output.clone().into_linear_view(),
-                dtype_to_storage_type(dtype),
-            );
-
-            output
+        // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+        // below assume a non-empty output. Return the empty output directly.
+        if shape_out.num_elements() == 0 {
+            return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
         }
-    }
+
+        let client = lhs.client.clone();
+        let num_elems = shape_out.num_elements();
+        let working_units = num_elems / vector_size as usize;
+
+        let cube_dim = CubeDim::new(&lhs.client, working_units);
+        let cube_count = calculate_cube_count_elemwise(&lhs.client, working_units, cube_dim);
+
+        unsafe {
+            if lhs.can_mut_broadcast(&rhs) {
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs),
+                    vector_size,
+                    lhs.clone().into_linear_view(),
+                    rhs.clone().into_linear_view_like(&lhs),
+                    lhs.as_linear_view_alias(0),
+                    dtype_to_storage_type(dtype),
+                );
+
+                lhs
+            } else if rhs.can_mut_broadcast(&lhs) {
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs),
+                    vector_size,
+                    lhs.into_linear_view_like(&rhs),
+                    rhs.clone().into_linear_view(),
+                    rhs.as_linear_view_alias(1),
+                    dtype_to_storage_type(dtype),
+                );
+
+                rhs
+            } else {
+                let output =
+                    empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
+
+                kernel_binop::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(lhs, rhs, output),
+                    vector_size,
+                    lhs.into_linear_view_like(&output),
+                    rhs.into_linear_view_like(&output),
+                    output.clone().into_linear_view(),
+                    dtype_to_storage_type(dtype),
+                );
+
+                output
+            }
+        }
+    })
 }
 
 /// Calculate the four-quadrant inverse tangent of `lhs / rhs`.

--- a/crates/burn-cubecl/src/kernel/memory_order.rs
+++ b/crates/burn-cubecl/src/kernel/memory_order.rs
@@ -1,0 +1,111 @@
+//! Walking an elementwise kernel in the order its operands occupy memory.
+//!
+//! The elementwise kernels take every operand through a linear view that walks
+//! the *logical* dimension order, and allocate their output contiguous in that
+//! order. That is the right order only when the operands are laid out that way.
+//! A convolution hands its consumer a channels-last tensor presented in NCHW,
+//! and such a kernel then walks it strided — and because the logical last
+//! dimension is not the contiguous one, it cannot vectorize either.
+//!
+//! An elementwise operation does not care what a dimension means, only that
+//! every operand is walked in step. So the operands are handed to the kernel
+//! permuted into the order the bulk of them occupy memory in. The output is
+//! then allocated dense in that order, an operand already in it is walked
+//! linearly and vectorized, one that disagrees is walked strided exactly as
+//! before, and the result is permuted back to the logical order before it is
+//! handed on. A permute is a change of metadata, so none of this moves data.
+
+use burn_std::{
+    Shape,
+    tensor::layout::{DimOrder, is_contiguous_order, nested_dim_order},
+};
+
+use crate::{ops::permute, tensor::CubeTensor};
+
+/// Runs `launch` with the operands permuted into their memory order, and
+/// permutes what it returns back.
+///
+/// `output_shape` is the shape the kernel will write — the broadcast of the
+/// operands for a binary operation, the operand's own for a unary one. Only
+/// operands of exactly that shape vote on the order: a broadcast operand is
+/// read from cache whatever the order is, so it has no stake, and it permutes
+/// along without changing whether it broadcasts.
+pub(crate) fn in_memory_order<const N: usize>(
+    operands: [CubeTensor; N],
+    output_shape: &Shape,
+    launch: impl FnOnce([CubeTensor; N]) -> CubeTensor,
+) -> CubeTensor {
+    let Some(order) = MemoryOrder::of(&operands, output_shape) else {
+        return launch(operands);
+    };
+
+    let presented = operands.map(|operand| order.present(operand));
+
+    order.restore(launch(presented))
+}
+
+/// The permutation that presents a set of operands in their memory order, and
+/// its inverse.
+struct MemoryOrder {
+    axes: Vec<usize>,
+    inverse: Vec<usize>,
+}
+
+impl MemoryOrder {
+    /// The order the operands carrying the most bytes occupy memory in, or
+    /// `None` when that is the logical order already — the case that should
+    /// keep behaving exactly as it always has.
+    ///
+    /// Ties go to the logical order, so a pair of operands that disagree keeps
+    /// the contiguous walk rather than favouring whichever came first. Padding
+    /// under a dimension is tolerated: a pitched allocation leaves one, and
+    /// what is being decided is the walk order, which padding does not touch.
+    fn of(operands: &[CubeTensor], output_shape: &Shape) -> Option<Self> {
+        // A quantized operand's block layout has its own rules for a permute;
+        // leaving it in logical order costs nothing it was not already paying.
+        if operands.iter().any(|operand| operand.qparams.is_some()) {
+            return None;
+        }
+
+        let mut votes: Vec<(DimOrder, usize)> = Vec::new();
+
+        for operand in operands {
+            if operand.meta.shape() != output_shape {
+                continue;
+            }
+            let Some(order) = nested_dim_order(operand.meta.shape(), operand.meta.strides()) else {
+                continue;
+            };
+            let bytes = operand.meta.num_elements() * operand.dtype.size();
+
+            match votes.iter_mut().find(|(candidate, _)| candidate == &order) {
+                Some((_, total)) => *total += bytes,
+                None => votes.push((order, bytes)),
+            }
+        }
+
+        let (winner, _) = votes
+            .into_iter()
+            .max_by_key(|(order, bytes)| (*bytes, is_contiguous_order(order)))?;
+
+        if is_contiguous_order(&winner) {
+            return None;
+        }
+
+        let axes: Vec<usize> = winner.iter().copied().collect();
+        let mut inverse = vec![0; axes.len()];
+        for (position, &axis) in axes.iter().enumerate() {
+            inverse[axis] = position;
+        }
+
+        Some(Self { axes, inverse })
+    }
+
+    fn present(&self, tensor: CubeTensor) -> CubeTensor {
+        permute(tensor, &self.axes)
+    }
+
+    fn restore(&self, tensor: CubeTensor) -> CubeTensor {
+        permute(tensor, &self.inverse)
+    }
+}

--- a/crates/burn-cubecl/src/kernel/memory_order.rs
+++ b/crates/burn-cubecl/src/kernel/memory_order.rs
@@ -10,10 +10,15 @@
 //! An elementwise operation does not care what a dimension means, only that
 //! every operand is walked in step. So the operands are handed to the kernel
 //! permuted into the order the bulk of them occupy memory in. The output is
-//! then allocated dense in that order, an operand already in it is walked
-//! linearly and vectorized, one that disagrees is walked strided exactly as
-//! before, and the result is permuted back to the logical order before it is
-//! handed on. A permute is a change of metadata, so none of this moves data.
+//! allocated dense in that order when a fresh buffer is needed; in-place writes
+//! retain the operand's storage. Matching dense operands can be read linearly,
+//! while vectorization still depends on the strides and all operands. The result
+//! is permuted back to logical order. Permutation changes metadata, not data.
+//! This is a locality heuristic, not a guarantee of faster execution for every
+//! shape or consumer. A fresh result can retain a nonlogical physical layout;
+//! a later reshape that cannot be expressed through strides must materialize
+//! logical value order. The extra copy can outweigh the elementwise speedup.
+//! Choosing the order here cannot account for consumers that have not run yet.
 
 use burn_std::{
     Shape,
@@ -27,21 +32,28 @@ use crate::{ops::permute, tensor::CubeTensor};
 ///
 /// `output_shape` is the shape the kernel will write — the broadcast of the
 /// operands for a binary operation, the operand's own for a unary one. Only
-/// operands of exactly that shape vote on the order: a broadcast operand is
-/// read from cache whatever the order is, so it has no stake, and it permutes
-/// along without changing whether it broadcasts.
+/// operands of exactly that shape vote on the order. This favors full-sized
+/// inputs over broadcast parameters; large broadcast inputs may still incur
+/// significant traffic. Every operand permutes along with the output shape.
 pub(crate) fn in_memory_order<const N: usize>(
     operands: [CubeTensor; N],
-    output_shape: &Shape,
-    launch: impl FnOnce([CubeTensor; N]) -> CubeTensor,
+    output_shape: Shape,
+    launch: impl FnOnce([CubeTensor; N], Shape) -> CubeTensor,
 ) -> CubeTensor {
-    let Some(order) = MemoryOrder::of(&operands, output_shape) else {
-        return launch(operands);
+    let Some(order) = MemoryOrder::of(&operands, &output_shape) else {
+        return launch(operands, output_shape);
     };
 
     let presented = operands.map(|operand| order.present(operand));
 
-    order.restore(launch(presented))
+    let shape = Shape::from(
+        order
+            .axes
+            .iter()
+            .map(|&axis| output_shape[axis])
+            .collect::<Vec<_>>(),
+    );
+    order.restore(launch(presented, shape))
 }
 
 /// The permutation that presents a set of operands in their memory order, and
@@ -67,28 +79,61 @@ impl MemoryOrder {
             return None;
         }
 
-        let mut votes: Vec<(DimOrder, usize)> = Vec::new();
+        Self::from_layouts(
+            operands.iter().map(|operand| {
+                (
+                    operand.meta.shape().as_slice(),
+                    &operand.meta.strides()[..],
+                    operand.dtype.size(),
+                )
+            }),
+            output_shape,
+        )
+    }
 
-        for operand in operands {
-            if operand.meta.shape() != output_shape {
+    fn from_layouts<'a>(
+        layouts: impl Iterator<Item = (&'a [usize], &'a [usize], usize)> + Clone,
+        output_shape: &[usize],
+    ) -> Option<Self> {
+        // The common logical walk needs neither sorting nor allocation. Ignore
+        // singleton strides: expanding [1024] to [1, 1024] gives [0, 1], which
+        // already has the right walk and must keep its vectorizable last axis.
+        if layouts
+            .clone()
+            .all(|(shape, strides, _)| shape != output_shape || nests_logically(shape, strides))
+        {
+            return None;
+        }
+
+        let mut votes: Vec<(DimOrder, usize)> = Vec::new();
+        for (shape, strides, element_size) in layouts {
+            if shape != output_shape {
                 continue;
             }
-            let Some(order) = nested_dim_order(operand.meta.shape(), operand.meta.strides()) else {
+            let Some(mut order) = nested_dim_order(shape, strides) else {
                 continue;
             };
-            let bytes = operand.meta.num_elements() * operand.dtype.size();
-
+            if nests_logically(shape, strides) {
+                order = Shape::from((0..shape.len()).collect::<Vec<_>>());
+            } else {
+                // Singleton placement carries no traffic. Put these axes first
+                // in logical order, so equivalent walks share a vote and a real
+                // innermost axis remains available for vectorization.
+                order.sort_by_key(|&axis| {
+                    (shape[axis] != 1, if shape[axis] == 1 { axis } else { 0 })
+                });
+            }
+            let bytes = shape.iter().product::<usize>() * element_size;
             match votes.iter_mut().find(|(candidate, _)| candidate == &order) {
                 Some((_, total)) => *total += bytes,
                 None => votes.push((order, bytes)),
             }
         }
 
-        let (winner, _) = votes
-            .into_iter()
-            .max_by_key(|(order, bytes)| (*bytes, is_contiguous_order(order)))?;
-
-        if is_contiguous_order(&winner) {
+        let max_bytes = votes.iter().map(|(_, bytes)| *bytes).max()?;
+        let mut winners = votes.into_iter().filter(|(_, bytes)| *bytes == max_bytes);
+        let (winner, _) = winners.next()?;
+        if winners.next().is_some() || is_contiguous_order(&winner) {
             return None;
         }
 
@@ -107,5 +152,159 @@ impl MemoryOrder {
 
     fn restore(&self, tensor: CubeTensor) -> CubeTensor {
         permute(tensor, &self.inverse)
+    }
+}
+
+/// Whether non-singleton dimensions nest in logical order, with padding allowed.
+fn nests_logically(shape: &[usize], strides: &[usize]) -> bool {
+    if shape.len() != strides.len() {
+        return false;
+    }
+    let mut expected = 1;
+    for (&size, &stride) in shape.iter().zip(strides).rev() {
+        if size == 1 {
+            continue;
+        }
+        if stride < expected {
+            return false;
+        }
+        expected = stride * size;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn singleton_strides_do_not_reorder_a_logical_walk() {
+        for strides in [[0, 1], [1, 1], [1024, 1]] {
+            assert!(
+                MemoryOrder::from_layouts(
+                    [([1, 1024].as_slice(), strides.as_slice(), 4)].into_iter(),
+                    &[1, 1024],
+                )
+                .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn singleton_axes_cannot_displace_the_innermost_data_axis() {
+        let shape = [4, 1, 8];
+        for strides in [[1, 0, 4], [1, 1, 4], [1, 32, 4]] {
+            let order = MemoryOrder::from_layouts(
+                [(shape.as_slice(), strides.as_slice(), 4)].into_iter(),
+                &shape,
+            )
+            .unwrap();
+            assert_eq!(order.axes, [1, 2, 0]);
+            let presented_shape = Shape::from(
+                order
+                    .axes
+                    .iter()
+                    .map(|&axis| shape[axis])
+                    .collect::<Vec<_>>(),
+            );
+            let presented_strides = burn_std::Strides::from(
+                order
+                    .axes
+                    .iter()
+                    .map(|&axis| strides[axis])
+                    .collect::<Vec<_>>(),
+            );
+            // A zero singleton stride must not turn the last axis into a
+            // broadcast axis. Other arbitrary strides can still limit alignment.
+            if strides[1] == 0 {
+                assert_eq!(
+                    cubecl::tensor_vector_size_parallel(
+                        [4, 2, 1].into_iter(),
+                        &presented_shape,
+                        &presented_strides,
+                        2,
+                    ),
+                    4
+                );
+            }
+            for axis in 0..shape.len() {
+                assert_eq!(order.axes[order.inverse[axis]], axis);
+            }
+        }
+    }
+
+    #[test]
+    fn conflicting_nonlogical_votes_tie_in_either_operand_order() {
+        let shape = [2, 3, 4];
+        let layouts = [
+            (shape.as_slice(), [12, 1, 3].as_slice(), 4),
+            (shape.as_slice(), [4, 8, 1].as_slice(), 4),
+        ];
+        assert!(MemoryOrder::from_layouts(layouts.into_iter(), &shape).is_none());
+        assert!(MemoryOrder::from_layouts(layouts.into_iter().rev(), &shape).is_none());
+    }
+
+    #[test]
+    fn a_logical_and_nonlogical_vote_tie() {
+        let shape = [2, 3, 4];
+        assert!(
+            MemoryOrder::from_layouts(
+                [
+                    (shape.as_slice(), [12, 1, 3].as_slice(), 4),
+                    (shape.as_slice(), [12, 4, 1].as_slice(), 4),
+                ]
+                .into_iter(),
+                &shape
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn equivalent_singleton_layouts_share_their_vote() {
+        let shape = [4, 1, 8];
+        let order = MemoryOrder::from_layouts(
+            [
+                (shape.as_slice(), [1, 0, 4].as_slice(), 4),
+                (shape.as_slice(), [1, 32, 4].as_slice(), 4),
+                (shape.as_slice(), [8, 8, 1].as_slice(), 4),
+            ]
+            .into_iter(),
+            &shape,
+        )
+        .unwrap();
+        assert_eq!(order.axes, [1, 2, 0]);
+    }
+
+    #[test]
+    fn votes_are_weighted_by_bytes() {
+        let shape = [2, 3, 4];
+        let order = MemoryOrder::from_layouts(
+            [
+                (shape.as_slice(), [12, 1, 3].as_slice(), 4),
+                (shape.as_slice(), [12, 4, 1].as_slice(), 2),
+            ]
+            .into_iter(),
+            &shape,
+        )
+        .unwrap();
+        assert_eq!(order.axes, [0, 2, 1]);
+    }
+
+    #[test]
+    fn padded_layouts_vote_but_broadcast_and_overlapping_layouts_do_not() {
+        let shape = [2, 3, 4];
+        let order = MemoryOrder::from_layouts(
+            [
+                (shape.as_slice(), [32, 1, 8].as_slice(), 4),
+                (shape.as_slice(), [0, 4, 1].as_slice(), 4),
+                (shape.as_slice(), [1, 1, 1].as_slice(), 4),
+                ([1, 3, 4].as_slice(), [12, 4, 1].as_slice(), 8),
+            ]
+            .into_iter(),
+            &shape,
+        )
+        .unwrap();
+        assert_eq!(order.axes, [0, 2, 1]);
     }
 }

--- a/crates/burn-cubecl/src/kernel/mod.rs
+++ b/crates/burn-cubecl/src/kernel/mod.rs
@@ -10,6 +10,7 @@ mod contiguous;
 mod cross;
 mod index;
 mod mask;
+mod memory_order;
 mod unary_float;
 mod unary_int;
 mod unary_numeric;

--- a/crates/burn-cubecl/src/kernel/unary_float.rs
+++ b/crates/burn-cubecl/src/kernel/unary_float.rs
@@ -1,3 +1,4 @@
+use crate::kernel::memory_order::in_memory_order;
 use crate::{
     kernel::utils::address_type,
     ops::{max_vector_size, numeric::empty_device_dtype},
@@ -47,54 +48,57 @@ where
     for<'a> Args: FnOnce(&'a ()) -> RuntimeArg<O::Options>,
     O: FloatUnaryOpFamily,
 {
-    let vector_size = max_vector_size(&tensor);
+    let output_shape = tensor.shape();
+    in_memory_order([tensor], &output_shape, |[tensor]| {
+        let vector_size = max_vector_size(&tensor);
 
-    let client = tensor.client.clone();
-    let num_elems = tensor.meta.num_elements();
+        let client = tensor.client.clone();
+        let num_elems = tensor.meta.num_elements();
 
-    let working_units = num_elems / vector_size as usize;
-    let cube_dim = CubeDim::new(&tensor.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
-    let dtype = tensor.dtype;
+        let working_units = num_elems / vector_size as usize;
+        let cube_dim = CubeDim::new(&tensor.client, working_units);
+        let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
+        let dtype = tensor.dtype;
 
-    unsafe {
-        if tensor.can_mut() && tensor.is_nonoverlapping() {
-            unary_float::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor),
-                vector_size,
-                tensor.clone().into_linear_view(),
-                tensor.as_linear_view_alias(0),
-                args(&()),
-                dtype_to_storage_type(dtype),
-            );
+        unsafe {
+            if tensor.can_mut() && tensor.is_nonoverlapping() {
+                unary_float::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor),
+                    vector_size,
+                    tensor.clone().into_linear_view(),
+                    tensor.as_linear_view_alias(0),
+                    args(&()),
+                    dtype_to_storage_type(dtype),
+                );
 
-            tensor
-        } else {
-            let output = empty_device_dtype(
-                tensor.client.clone(),
-                tensor.device.clone(),
-                tensor.shape(),
-                tensor.dtype,
-            );
+                tensor
+            } else {
+                let output = empty_device_dtype(
+                    tensor.client.clone(),
+                    tensor.device.clone(),
+                    tensor.shape(),
+                    tensor.dtype,
+                );
 
-            unary_float::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor, output),
-                vector_size,
-                tensor.into_linear_view(),
-                output.clone().into_linear_view(),
-                args(&()),
-                dtype_to_storage_type(dtype),
-            );
+                unary_float::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor, output),
+                    vector_size,
+                    tensor.into_linear_view(),
+                    output.clone().into_linear_view(),
+                    args(&()),
+                    dtype_to_storage_type(dtype),
+                );
 
-            output
+                output
+            }
         }
-    }
+    })
 }
 
 /// Use comptime enum to implement all unary operations that don't have any input argument in the

--- a/crates/burn-cubecl/src/kernel/unary_float.rs
+++ b/crates/burn-cubecl/src/kernel/unary_float.rs
@@ -49,7 +49,7 @@ where
     O: FloatUnaryOpFamily,
 {
     let output_shape = tensor.shape();
-    in_memory_order([tensor], &output_shape, |[tensor]| {
+    in_memory_order([tensor], output_shape, |[tensor], shape_out| {
         let vector_size = max_vector_size(&tensor);
 
         let client = tensor.client.clone();
@@ -79,7 +79,7 @@ where
                 let output = empty_device_dtype(
                     tensor.client.clone(),
                     tensor.device.clone(),
-                    tensor.shape(),
+                    shape_out,
                     tensor.dtype,
                 );
 

--- a/crates/burn-cubecl/src/kernel/unary_numeric.rs
+++ b/crates/burn-cubecl/src/kernel/unary_numeric.rs
@@ -1,3 +1,4 @@
+use crate::kernel::memory_order::in_memory_order;
 use crate::{
     kernel::utils::address_type,
     ops::{max_vector_size, numeric::empty_device_dtype},
@@ -47,51 +48,54 @@ where
     for<'a> Args: FnOnce(&'a ()) -> RuntimeArg<O::Options>,
     O: NumericUnaryOpFamily,
 {
-    let vector_size = max_vector_size(&tensor);
-    let client = tensor.client.clone();
-    let num_elems = tensor.meta.num_elements();
+    let output_shape = tensor.shape();
+    in_memory_order([tensor], &output_shape, |[tensor]| {
+        let vector_size = max_vector_size(&tensor);
+        let client = tensor.client.clone();
+        let num_elems = tensor.meta.num_elements();
 
-    let working_units = num_elems / vector_size as usize;
-    let cube_dim = CubeDim::new(&tensor.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
-    let dtype = tensor.dtype;
+        let working_units = num_elems / vector_size as usize;
+        let cube_dim = CubeDim::new(&tensor.client, working_units);
+        let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
+        let dtype = tensor.dtype;
 
-    unsafe {
-        if tensor.can_mut() && tensor.is_nonoverlapping() {
-            unary_numeric::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor),
-                vector_size,
-                tensor.clone().into_linear_view(),
-                tensor.as_linear_view_alias(0),
-                args(&()),
-                dtype_to_storage_type(dtype),
-            );
+        unsafe {
+            if tensor.can_mut() && tensor.is_nonoverlapping() {
+                unary_numeric::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor),
+                    vector_size,
+                    tensor.clone().into_linear_view(),
+                    tensor.as_linear_view_alias(0),
+                    args(&()),
+                    dtype_to_storage_type(dtype),
+                );
 
-            tensor
-        } else {
-            let output = empty_device_dtype(
-                tensor.client.clone(),
-                tensor.device.clone(),
-                tensor.shape(),
-                tensor.dtype,
-            );
+                tensor
+            } else {
+                let output = empty_device_dtype(
+                    tensor.client.clone(),
+                    tensor.device.clone(),
+                    tensor.shape(),
+                    tensor.dtype,
+                );
 
-            unary_numeric::launch_unchecked::<O>(
-                &client,
-                cube_count,
-                cube_dim,
-                address_type!(tensor, output),
-                vector_size,
-                tensor.into_linear_view(),
-                output.clone().into_linear_view(),
-                args(&()),
-                dtype_to_storage_type(dtype),
-            );
+                unary_numeric::launch_unchecked::<O>(
+                    &client,
+                    cube_count,
+                    cube_dim,
+                    address_type!(tensor, output),
+                    vector_size,
+                    tensor.into_linear_view(),
+                    output.clone().into_linear_view(),
+                    args(&()),
+                    dtype_to_storage_type(dtype),
+                );
 
-            output
+                output
+            }
         }
-    }
+    })
 }

--- a/crates/burn-cubecl/src/kernel/unary_numeric.rs
+++ b/crates/burn-cubecl/src/kernel/unary_numeric.rs
@@ -49,7 +49,7 @@ where
     O: NumericUnaryOpFamily,
 {
     let output_shape = tensor.shape();
-    in_memory_order([tensor], &output_shape, |[tensor]| {
+    in_memory_order([tensor], output_shape, |[tensor], shape_out| {
         let vector_size = max_vector_size(&tensor);
         let client = tensor.client.clone();
         let num_elems = tensor.meta.num_elements();
@@ -78,7 +78,7 @@ where
                 let output = empty_device_dtype(
                     tensor.client.clone(),
                     tensor.device.clone(),
-                    tensor.shape(),
+                    shape_out,
                     tensor.dtype,
                 );
 

--- a/crates/burn-std/src/tensor/layout.rs
+++ b/crates/burn-std/src/tensor/layout.rs
@@ -1,0 +1,241 @@
+//! The order a tensor's dimensions occupy memory in.
+//!
+//! A tensor's strides say which dimension is innermost, which next, and so on
+//! outward — its *dimension order*. Contiguous NCHW is the identity order; a
+//! convolution that computes channels-last and hands back a permuted view is
+//! `[0, 2, 3, 1]`. A kernel that iterates a tensor in its own dimension order
+//! reads it linearly; one that iterates in any other order reads it strided.
+//!
+//! Two questions are asked here. [dim_order] asks for the order of a tensor
+//! that is *dense* — that fills its buffer with no gaps — which is what a kernel
+//! needs before it may treat the buffer as a flat run of elements.
+//! [nested_dim_order] asks only that the dimensions *nest*, tolerating the gap a
+//! pitched or tile-aligned allocation leaves under a dimension, which is enough
+//! to decide what order to iterate in.
+
+use alloc::vec::Vec;
+
+use crate::Shape;
+
+/// The order a tensor's dimensions appear in memory, outermost first.
+///
+/// `[0, 1, 2, 3]` is contiguous NCHW; `[0, 2, 3, 1]` is NHWC. This is the same
+/// convention as the permutation passed to `Tensor::permute`.
+pub type DimOrder = Shape;
+
+/// The dimension order of a tensor that is dense in memory, or `None` if it is
+/// not dense.
+///
+/// Dense means the strides are exactly a permutation of contiguous strides: no
+/// gaps, no overlap, no broadcasting. Use [nested_dim_order] when only an
+/// iteration order is needed and gaps in storage are acceptable.
+///
+/// Dimensions of size one are ignored while checking density — their stride is
+/// arbitrary and carries no traffic — but they keep a position in the returned
+/// order so it stays a permutation of `0..rank`.
+pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
+    dim_order_inner(shape, strides, Padding::Rejected)
+}
+
+/// The dimension order of a tensor whose dimensions nest without overlapping,
+/// or `None` if they do not.
+///
+/// Weaker than [dim_order], which additionally requires consecutive elements
+/// without gaps. A dimension may sit at a larger stride than the extents inside it
+/// need, which is what a pitched or tile-aligned allocation produces: 48
+/// channels held innermost on a 64-element tile have stride 64 where a dense
+/// tensor would have 48.
+///
+/// Iterating in this order can improve locality, but reads must still use the
+/// tensor's actual strides. Gaps can affect memory transactions and vectorization;
+/// accepting an order does not guarantee dense-access performance. This also
+/// accepts sliced views whose dimensions satisfy the same nesting condition.
+/// Anything reinterpreting a buffer as a flat run of elements must keep asking
+/// [dim_order].
+pub fn nested_dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
+    dim_order_inner(shape, strides, Padding::Allowed)
+}
+
+#[derive(Clone, Copy)]
+enum Padding {
+    Allowed,
+    Rejected,
+}
+
+fn dim_order_inner(shape: &[usize], strides: &[usize], padding: Padding) -> Option<DimOrder> {
+    let rank = shape.len();
+
+    if rank != strides.len() {
+        return None;
+    }
+
+    let mut order: Vec<usize> = (0..rank).collect();
+    // Descending stride is outermost first. The dimension index breaks ties so
+    // that equal strides — which only happens among size-one dimensions — give
+    // a deterministic order rather than one that depends on the sort.
+    order.sort_by(|a, b| strides[*b].cmp(&strides[*a]).then(a.cmp(b)));
+
+    let mut expected = 1;
+
+    for &axis in order.iter().rev() {
+        if shape[axis] == 1 {
+            continue;
+        }
+        match padding {
+            // A gap is what makes the tensor padded rather than dense; an
+            // overlap is not a layout at all.
+            Padding::Allowed if strides[axis] < expected => return None,
+            Padding::Rejected if strides[axis] != expected => return None,
+            _ => {}
+        }
+        // Where the stride is exactly `expected` this is `expected *= shape[axis]`,
+        // so the dense walk is the padded one with the gaps taken out.
+        expected = strides[axis] * shape[axis];
+    }
+
+    Some(Shape::from(order))
+}
+
+/// Whether a dimension order is the contiguous one, `[0, 1, .., rank - 1]`.
+pub fn is_contiguous_order(order: &[usize]) -> bool {
+    order.iter().enumerate().all(|(pos, axis)| pos == *axis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_is_the_identity_order() {
+        let shape = [2, 48, 16, 16];
+        let strides = [48 * 16 * 16, 16 * 16, 16, 1];
+
+        assert_eq!(
+            dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 1, 2, 3]))
+        );
+    }
+
+    #[test]
+    fn nhwc_memory_gives_the_nhwc_order() {
+        // What a convolution hands its successor: shape is NCHW, memory is NHWC.
+        let shape = [2, 48, 16, 16];
+        let strides = [16 * 16 * 48, 1, 16 * 48, 48];
+
+        assert_eq!(
+            dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 2, 3, 1]))
+        );
+    }
+
+    #[test]
+    fn broadcast_is_not_dense() {
+        let shape = [2, 48, 16, 16];
+        let strides = [0, 1, 0, 0];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn a_slice_is_not_dense() {
+        // A view into a wider tensor: the row stride overshoots the row.
+        let shape = [4, 8];
+        let strides = [16, 1];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn size_one_dimensions_do_not_decide_density() {
+        // A per-channel parameter presented at full rank. The strides of the
+        // degenerate dimensions say nothing, and must not make it non-dense.
+        let shape = [1, 48, 1, 1];
+        let strides = [48, 1, 48, 48];
+
+        assert!(dim_order(&shape, &strides).is_some());
+    }
+
+    #[test]
+    fn the_order_ends_at_the_innermost_dimension() {
+        let shape = [2, 48, 16, 16];
+
+        let contiguous = dim_order(&shape, &[48 * 16 * 16, 16 * 16, 16, 1]).unwrap();
+        let nhwc = dim_order(&shape, &[16 * 16 * 48, 1, 16 * 48, 48]).unwrap();
+
+        assert_eq!(contiguous.last(), Some(&3));
+        assert_eq!(nhwc.last(), Some(&1));
+    }
+
+    #[test]
+    fn order_is_a_permutation() {
+        assert!(is_contiguous_order(&[0, 1, 2, 3]));
+        assert!(!is_contiguous_order(&[0, 2, 3, 1]));
+    }
+
+    #[test]
+    fn a_dense_tensor_nests_in_the_order_it_is_dense_in() {
+        let shape = [2, 48, 16, 16];
+
+        for strides in [
+            [48 * 16 * 16, 16 * 16, 16, 1],
+            [16 * 16 * 48, 1, 16 * 48, 48],
+        ] {
+            let dense = dim_order(&shape, &strides);
+            assert!(dense.is_some());
+            assert_eq!(nested_dim_order(&shape, &strides), dense);
+        }
+    }
+
+    #[test]
+    fn padding_under_the_innermost_dimension_keeps_the_nhwc_order() {
+        let shape = [2, 48, 16, 16];
+        let strides = [16 * 16 * 64, 1, 16 * 64, 64];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 2, 3, 1]))
+        );
+    }
+
+    #[test]
+    fn padding_above_the_innermost_dimension_is_nesting_too() {
+        let shape = [4, 8];
+        let strides = [16, 1];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            Some(Shape::from(vec![0, 1]))
+        );
+    }
+
+    #[test]
+    fn overlapping_dimensions_are_not_an_order_under_either() {
+        let shape = [4, 8];
+        let strides = [4, 1];
+
+        assert_eq!(dim_order(&shape, &strides), None);
+        assert_eq!(nested_dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn a_broadcast_dimension_still_cannot_vote() {
+        let shape = [2, 48, 16, 16];
+        let strides = [0, 1, 0, 0];
+
+        assert_eq!(nested_dim_order(&shape, &strides), None);
+    }
+
+    #[test]
+    fn size_one_dimensions_neither_pad_nor_constrain_nesting() {
+        let shape = [1, 48, 1, 1];
+        let strides = [48, 1, 48, 48];
+
+        assert_eq!(
+            nested_dim_order(&shape, &strides),
+            dim_order(&shape, &strides)
+        );
+        assert!(nested_dim_order(&shape, &strides).is_some());
+    }
+}

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -2,6 +2,8 @@
 pub mod container;
 /// Tensor data type definitions.
 pub mod dtype;
+/// The order a tensor's dimensions occupy memory in.
+pub mod layout;
 /// Batched matmul transformation utilities.
 pub mod matmul;
 /// Quantization data representation.
@@ -12,6 +14,7 @@ pub mod shape;
 pub mod slice;
 
 pub use dtype::*;
+pub use layout::*;
 pub use matmul::*;
 pub use quantization::*;
 pub use shape::*;


### PR DESCRIPTION
### Changes

The elementwise kernels take every operand through a linear view that walks the logical dimension order, and allocate their output contiguous in that order. A convolution hands its consumer a channels-last tensor presented in NCHW, so any elementwise operation that does not fuse (a gradient's `grad * x` in a backward pass, a scalar multiply, an activation) walked it strided, and because the logical last dimension is not the contiguous one it could not vectorize either. Now that the fusion planner (the previous PR in this stack) keeps such tensors channels-last, every unfused consumer pays this cost on every activation.

An elementwise operation does not care what a dimension means, only that its operands are walked in step. `in_memory_order` hands the operands to the kernel permuted into the order the bulk of them occupy memory in, a byte-weighted vote among the operands of the output's shape, with ties going to the logical order and padding under a dimension tolerated, and permutes the result back. The output is then allocated dense in that order: an operand already in it is walked linearly and vectorized, one that disagrees is walked strided exactly as before. A permute is a change of metadata, so no data moves, and a quantized operand is left alone. This applies to the float and numeric binary, scalar and unary launchers.

The stack's first commit moves the `dim_order`, `nested_dim_order` and `is_contiguous_order` helpers from `burn-cubecl-fusion` to `burn-std`, since these kernels need to ask the same question about a tensor's strides and `burn-cubecl` cannot depend on the fusion crate; the fusion planner re-exports them from the same path it always did, with no behaviour change.

### Testing

Six tests compare each kernel on a channels-last operand against the same kernel on a contiguous copy, on the plain backend and under fusion: `binary_with_both_operands_alive_matches_the_contiguous_answer`, `binary_consuming_a_permuted_operand_matches_the_contiguous_answer`, `binary_with_a_broadcast_operand_matches_the_contiguous_answer`, `a_permuted_and_a_contiguous_operand_together_match_the_contiguous_answer`, `scalar_on_a_permuted_operand_matches_the_contiguous_answer`, and `unary_on_a_permuted_operand_matches_the_contiguous_answer`.

### Reproduction

https://github.com/Marc-AnthonyG/burn-reproduction/tree/main/cases/elementwise-memory-order

Run with `cargo run --release -p elementwise-memory-order --features cuda`.

## Metal
<img width="828" height="288" alt="Screenshot 2026-09-08 at 3 25 47 PM" src="https://github.com/user-attachments/assets/77b92a98-738d-40d4-8fcd-04b55371ac0f" />

## Cuda
<img width="821" height="300" alt="Screenshot 2026-09-08 at 3 23 54 PM" src="https://github.com/user-attachments/assets/06727a4b-3169-4258-a001-005210fd0ea2" />
