### PR TITLE
fix(flex): avoid overflow in boolean select updates

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/bool/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/select.rs
@@ -90,6 +90,59 @@ fn should_select_add_bool_true_or_true_accumulation() {
 }
 
 #[test]
+fn should_select_add_bool_many_duplicate_indices() {
+    let device = Default::default();
+    for count in [256, 512] {
+        let tensor = TestTensorBool::<1>::from_data([false, true, false], &device);
+        let dtype = tensor.dtype();
+        let indices =
+            TestTensorInt::from_data(TensorData::new(vec![0i32; count], [count]), &device);
+        let values =
+            TestTensorBool::<1>::from_data(TensorData::new(vec![true; count], [count]), &device);
+
+        let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Add);
+
+        assert_eq!(output.dtype(), dtype);
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([true, true, false]), false);
+    }
+}
+
+#[test]
+fn should_select_add_bool_many_duplicate_rows() {
+    let device = Default::default();
+    let tensor =
+        TestTensorBool::<2>::from_data([[false, true, false], [true, false, true]], &device);
+    let indices = TestTensorInt::from_data([0; 256], &device);
+    let values = TestTensorBool::<2>::from_data([[true, false, false]; 256], &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Add);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[true, true, false], [true, false, true]]),
+        false,
+    );
+}
+
+#[test]
+fn should_select_add_bool_many_duplicate_columns_from_transposed_views() {
+    let device = Default::default();
+    let tensor =
+        TestTensorBool::<2>::from_data([[false, true, false], [true, false, true]], &device)
+            .transpose();
+    let indices = TestTensorInt::from_data([0; 256], &device);
+    let values = TestTensorBool::<2>::from_data([[true, false, false]; 256], &device).transpose();
+
+    let output = tensor.select_assign(1, indices, values, IndexingUpdateOp::Add);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[true, true], [true, false], [false, true]]),
+        false,
+    );
+}
+
+#[test]
 fn should_match_default_implementation_behavior() {
     // Verify optimized implementation matches original default logic
     let device = Default::default();

--- a/crates/burn-flex/src/ops/bool.rs
+++ b/crates/burn-flex/src/ops/bool.rs
@@ -366,15 +366,7 @@ impl BoolTensorOps<Flex> for Flex {
         indices: IntTensor<Flex>,
         value: BoolTensor<Flex>,
     ) -> BoolTensor<Flex> {
-        let mut result = crate::ops::gather_scatter::select_add::<u8>(tensor, dim, indices, value);
-        // Clamp to 0/1: select_add sums u8 values, but bool OR saturates at 1
-        let storage: &mut [u8] = result.storage_mut();
-        for v in storage.iter_mut() {
-            if *v > 1 {
-                *v = 1;
-            }
-        }
-        result
+        crate::ops::gather_scatter::select_or(tensor, dim, indices, value)
     }
 
     fn bool_transpose(tensor: BoolTensor<Flex>) -> BoolTensor<Flex> {

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -1202,6 +1202,22 @@ pub fn select_add_i64(
 
 // Bool-specific operations
 
+/// Select OR for bool tensors: ORs values into tensor at positions specified by 1D indices.
+pub fn select_or(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    let dtype = tensor.dtype();
+    let result =
+        select_update::<u8, _>(tensor, dim, indices, value, "select_or", |target, value| {
+            *target |= value
+        });
+    // The shared update kernel tags its output as u8; retain the input's bool dtype.
+    FlexTensor::from_arc(result.data_arc(), result.layout().clone(), dtype)
+}
+
 pub fn gather_bool(tensor: FlexTensor, dim: usize, indices: FlexTensor) -> FlexTensor {
     gather::<u8>(tensor, dim, indices)
 }


### PR DESCRIPTION
## Checklist

- [x] Confirmed that `cargo run-checks` has been executed successfully.
- [x] Checked documentation impact: this restores the existing boolean OR contract; no API or book changes are needed.

## Related Issues/PRs

Fixes #5605.

## Changes

`Flex::bool_select_or` accumulated boolean updates in a `u8` before clamping to 0/1. With 256 true updates to the same index, debug builds panic on overflow and unchecked arithmetic can wrap the result to false.

Use OR in the existing indexed-update kernel instead. This keeps its shape and index validation, 2D fast paths, and view materialization, while retaining the original boolean dtype on the result. Duplicate updates now remain true regardless of their count; existing true values and unselected elements are preserved.

Add shared backend regressions for 256/512 duplicate indices, duplicate rows, and duplicate columns from transposed inputs.

## Testing

All three new regression tests fail on the original implementation:

```text
panicked at crates/burn-flex/src/ops/gather_scatter.rs:819:25:
attempt to add with overflow
test result: FAILED. 0 passed; 3 failed
```

With the fix, the complete boolean select group passes:

```text
BURN_DEVICE=flex cargo test --locked -p burn-backend-tests --no-default-features --features flex,std tensor::bool::ops::select
16 passed; 0 failed
```

- Complete release-mode Flex backend suite: 3,409 passed, 39 ignored, 0 failed.
- Independent code review: no blockers.

`cargo run-checks`: passed, including formatting, typos, dependency audit, workspace Clippy, no-std compilation, Flex backend tests, and linear algebra tests (3,604 passed, 43 ignored, 0 failed in total). Its embedded Git downloader could not reach GitHub for RustSec. The current official advisory database (`bf25f6575a93a35f30796c65c0ed91bee7fa19fd`) was fetched through GitHub's API, and the unchanged audit rules passed against that snapshot. The full validation command uses a temporary local database path with fetching disabled; the repository audit configuration is restored afterward.

## AI-assisted development

Codex assisted with investigation, implementation, regression testing, and an independent review of the change. The review checked the OR semantics, input/result dtype, storage ownership, and general/2D indexing paths. The tests above exercise the real backend.

Local toolchain note: the release build emitted a `rust-objcopy` debug-info stripping warning because its LLVM shared library is missing; compilation and all test commands still exited successfully.
