### PR TITLE
fix(flex): support unsigned dtypes in int_argmax/int_argmin

### DIFF
--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -776,6 +776,10 @@ pub fn argmax(tensor: FlexTensor, dim: usize) -> FlexTensor {
         DType::I16 => extremum_dim_with_indices::<i16, _>(&tensor, dim, |a, b| a > b).1,
         DType::I32 => extremum_dim_with_indices::<i32, _>(&tensor, dim, |a, b| a > b).1,
         DType::I64 => extremum_dim_with_indices::<i64, _>(&tensor, dim, |a, b| a > b).1,
+        DType::U8 => extremum_dim_with_indices::<u8, _>(&tensor, dim, |a, b| a > b).1,
+        DType::U16 => extremum_dim_with_indices::<u16, _>(&tensor, dim, |a, b| a > b).1,
+        DType::U32 => extremum_dim_with_indices::<u32, _>(&tensor, dim, |a, b| a > b).1,
+        DType::U64 => extremum_dim_with_indices::<u64, _>(&tensor, dim, |a, b| a > b).1,
         _ => panic!("argmax: unsupported dtype {:?}", tensor.dtype()),
     }
 }
@@ -832,6 +836,10 @@ pub fn argmin(tensor: FlexTensor, dim: usize) -> FlexTensor {
         DType::I16 => extremum_dim_with_indices::<i16, _>(&tensor, dim, |a, b| a < b).1,
         DType::I32 => extremum_dim_with_indices::<i32, _>(&tensor, dim, |a, b| a < b).1,
         DType::I64 => extremum_dim_with_indices::<i64, _>(&tensor, dim, |a, b| a < b).1,
+        DType::U8 => extremum_dim_with_indices::<u8, _>(&tensor, dim, |a, b| a < b).1,
+        DType::U16 => extremum_dim_with_indices::<u16, _>(&tensor, dim, |a, b| a < b).1,
+        DType::U32 => extremum_dim_with_indices::<u32, _>(&tensor, dim, |a, b| a < b).1,
+        DType::U64 => extremum_dim_with_indices::<u64, _>(&tensor, dim, |a, b| a < b).1,
         _ => panic!("argmin: unsupported dtype {:?}", tensor.dtype()),
     }
 }
@@ -2586,6 +2594,61 @@ mod tests {
             .map(|&v| v as i64)
             .collect();
         assert_eq!(values, vec![1]);
+    }
+
+    // Regression tests for https://github.com/tracel-ai/burn/issues/5608:
+    // `int_argmax`/`int_argmin` panicked on unsigned dtypes.
+    fn arg_indices(result: FlexTensor) -> Vec<isize> {
+        assert_eq!(result.layout().shape().to_vec(), vec![1]);
+        bytemuck::cast_slice(&result.into_data().bytes).to_vec()
+    }
+
+    #[test]
+    fn test_argmax_u8() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![1u8, 5, 3], [3]));
+        assert_eq!(arg_indices(Flex::int_argmax(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmax_u16() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![1u16, 5, 3], [3]));
+        assert_eq!(arg_indices(Flex::int_argmax(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmax_u32() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![1u32, 5, 3], [3]));
+        assert_eq!(arg_indices(Flex::int_argmax(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmax_u64() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![1u64, 5, 3], [3]));
+        assert_eq!(arg_indices(Flex::int_argmax(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmin_u8() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![3u8, 1, 2], [3]));
+        assert_eq!(arg_indices(Flex::int_argmin(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmin_u16() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![3u16, 1, 2], [3]));
+        assert_eq!(arg_indices(Flex::int_argmin(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmin_u32() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![3u32, 1, 2], [3]));
+        assert_eq!(arg_indices(Flex::int_argmin(tensor, 0)), vec![1]);
+    }
+
+    #[test]
+    fn test_argmin_u64() {
+        let tensor = FlexTensor::from_data(TensorData::new(vec![3u64, 1, 2], [3]));
+        assert_eq!(arg_indices(Flex::int_argmin(tensor, 0)), vec![1]);
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> Full `cargo run-checks` (xtask validate) does not pass on my Windows
> machine: it fails at the workspace-lint step compiling third-party
> `wgpu-hal v30.0.1` (`windows_core` 0.61 vs 0.62 `CanInto<ID3D12Heap>`
> conflict), which is unrelated to this change — `burn-flex` does not
> depend on `wgpu` at all. All checks relevant to this change pass, see
> Testing. No book update needed: this restores the expected behavior, no
> API or documented semantics change.

### Related Issues/PRs

Closes #5608

### Changes

`Flex::int_argmax` / `int_argmin` panicked with `unsupported dtype U8`
(and U16/U32/U64) because the dispatch in `crates/burn-flex/src/ops/reduce.rs`
only covered `I8..I64`, while `max_dim` / `min_dim` / `max_dim_with_indices`
in the same file handle all eight int dtypes.

Added the `U8`/`U16`/`U32`/`U64` arms to both `argmax` and `argmin` via
`extremum_dim_with_indices`, mirroring `max_dim_with_indices` (`>` for
argmax, `<` for argmin). No SIMD fast-path changes (that path only exists
for f32); no float/NaN behavior touched.

### Testing

- Reproduced the panic before the fix (`argmax: unsupported dtype U8` at
  `reduce.rs:779`, `argmin: unsupported dtype U32` at `reduce.rs:835`).
- Added 8 regression tests (`test_argmax_u8/u16/u32/u64`,
  `test_argmin_u8/u16/u32/u64`) covering every new arm.
- `cargo test -p burn-flex`: PASS — 399 passed, 0 failed.
- `cargo test -p burn-flex --lib ops::reduce::tests::test_arg`: PASS — 10/10.
- `cargo fmt --all -- --check`: PASS.
- `cargo clippy -p burn-flex --all-targets`: PASS, no warnings.
- `git diff --check`: PASS.
