### PR TITLE
test(fusion): change f32 expected value to oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.20",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
@@ -92,16 +92,22 @@ fn two_branch_conv_bn_add(dev: Device, dtype: DType) -> TensorData {
 }
 
 /// Two parallel conv+BN branches added together — the Fusion<f16> result must
-/// match reference.
+/// match the analytical reference.
 ///
 /// This test was failing only on Vulkan+Fusion+f16
 /// Reference: https://github.com/tracel-ai/burn/pull/4675
 #[test]
 fn fusion_f16_two_branch_conv_bn_add_matches_reference() {
     let fused_f16 = two_branch_conv_bn_add(Default::default(), DType::F16);
-    let reference_f32 = two_branch_conv_bn_add(Default::default(), DType::F32);
+
+    // Every convolution output is `3 * 0.5 * INIT`. Batch norm then divides by
+    // `sqrt(1 + EPS)`, and the two identical branches are added. Keep the oracle
+    // independent of the backend under test: running the graph again with F32 is
+    // still a fused GPU execution and can therefore fail for unrelated reasons.
+    let expected_value = (2.0 * 3.0 * 0.5 * INIT / (1.0 + EPS).sqrt()) as f32;
+    let expected = TensorData::full([1, CH, 32, 32], expected_value);
 
     fused_f16
         .convert_dtype(DType::F32)
-        .assert_approx_eq::<FloatElem>(&reference_f32, Tolerance::rel_abs(5e-3, 1e-2));
+        .assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(5e-3, 1e-2));
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Changes

Replace the expected value with an analytical reference. Preserves the original intent of the test, while making CI pass.