### PR TITLE
fix(cubecl): gate storage_tiled tests behind runtime features

### DIFF
--- a/crates/burn-cubecl/src/kernel/contiguous.rs
+++ b/crates/burn-cubecl/src/kernel/contiguous.rs
@@ -162,7 +162,10 @@ fn into_contiguous_quantized(tensor: CubeTensor, strategy: MemoryLayoutStrategy)
 /// A tensor packed into storage tiles through cubek, and what burn does with one: the matmul it
 /// was packed for reads it through its binding, every layout rewrite lays it back in rows first,
 /// and a row kernel refuses it.
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(feature = "wgpu", feature = "cpu", feature = "cuda", feature = "hip")
+))]
 mod storage_tiled {
     use burn_backend::{DType, cubecl::dtype_to_storage_type};
     use burn_std::{Shape, TensorData};


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Tests introduced in #5631 need to be feature gated otherwise they run on the CI with no adapter available

### Changes

Feature gate the tests
