### PR TITLE
perf(conv): accumulate a block of output channels across the kernel window

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -94,18 +94,60 @@ fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
         stride_oc,
     };
 
-    kernel_loop(
-        input,
-        weight,
-        &mut sum,
-        in_offs,
-        true,
-        weight_offs,
-        &loop_params,
-        0usize,
-        has_padding,
-        accumulate_lanes,
-    );
+    let vector_size_in = input.vector_size();
+    let block = comptime![usize::min(4, vector_size_out)];
+
+    if accumulate_lanes {
+        #[unroll]
+        for bi in 0..comptime![vector_size_out / block] {
+            let base_v = bi * block;
+            let mut lanes = Array::<Vector<E, NIn>>::new(block);
+
+            kernel_loop(
+                input,
+                weight,
+                &mut sum,
+                &mut lanes,
+                in_offs,
+                true,
+                weight_offs,
+                &loop_params,
+                0usize,
+                has_padding,
+                accumulate_lanes,
+                base_v,
+            );
+
+            #[unroll]
+            for j in 0..block {
+                let mut channel = sum.extract(base_v + j);
+
+                #[unroll]
+                for i in 0..vector_size_in {
+                    channel += lanes[j].extract(i);
+                }
+
+                sum.insert(base_v + j, channel);
+            }
+        }
+    } else {
+        let mut lanes = Array::<Vector<E, NIn>>::new(1usize);
+
+        kernel_loop(
+            input,
+            weight,
+            &mut sum,
+            &mut lanes,
+            in_offs,
+            true,
+            weight_offs,
+            &loop_params,
+            0usize,
+            has_padding,
+            accumulate_lanes,
+            0usize,
+        );
+    }
 
     output.write(ABSOLUTE_POS, sum);
 }
@@ -128,6 +170,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
     input: &Tensor<Vector<E, NIn>>,
     weight: &Tensor<Vector<E, NIn>>,
     sum: &mut Vector<E, NOut>,
+    lanes: &mut Array<Vector<E, NIn>>,
     in_offs: usize,
     in_bounds: bool,
     weight_offs: usize,
@@ -135,6 +178,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
     #[comptime] kernel_dim: usize,
     #[comptime] has_padding: bool,
     #[comptime] accumulate_lanes: bool,
+    #[comptime] base_v: usize,
 ) {
     if comptime![kernel_dim < params.kernel_shape.len()] {
         let out_idx = *params.out_pos.index(kernel_dim);
@@ -157,6 +201,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
                 input,
                 weight,
                 sum,
+                lanes,
                 in_offs,
                 in_bounds,
                 weight_offs,
@@ -164,6 +209,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
                 comptime![kernel_dim + 1],
                 has_padding,
                 accumulate_lanes,
+                base_v,
             );
         }
     } else {
@@ -171,12 +217,14 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
             input,
             weight,
             sum,
+            lanes,
             in_offs,
             in_bounds,
             weight_offs,
             params.in_c_per_group,
             params.stride_oc,
             accumulate_lanes,
+            base_v,
         );
     }
 }
@@ -186,23 +234,26 @@ fn kernel_loop_inner<E: Numeric, NIn: Size, NOut: Size>(
     input: &Tensor<Vector<E, NIn>>,
     weight: &Tensor<Vector<E, NIn>>,
     sum: &mut Vector<E, NOut>,
+    lanes: &mut Array<Vector<E, NIn>>,
     in_offs: usize,
     in_bounds: bool,
     weight_offs: usize,
     in_c_per_group: u32,
     stride_oc: usize,
     #[comptime] accumulate_lanes: bool,
+    #[comptime] base_v: usize,
 ) {
     if in_bounds {
         if accumulate_lanes {
             accumulate_in_lanes(
                 input,
                 weight,
-                sum,
+                lanes,
                 in_offs,
                 weight_offs,
                 in_c_per_group,
                 stride_oc,
+                base_v,
             );
         } else {
             accumulate_per_step(
@@ -218,39 +269,31 @@ fn kernel_loop_inner<E: Numeric, NIn: Size, NOut: Size>(
     }
 }
 
-/// One input read per output channel buys a channel loop with no dependency chain.
+/// One input read serves a whole block of output channels, and the block's accumulator outlives
+/// the kernel window, so a channel step costs one input load per block and never a fold.
 #[cube]
-fn accumulate_in_lanes<E: Numeric, NIn: Size, NOut: Size>(
+fn accumulate_in_lanes<E: Numeric, NIn: Size>(
     input: &Tensor<Vector<E, NIn>>,
     weight: &Tensor<Vector<E, NIn>>,
-    sum: &mut Vector<E, NOut>,
+    lanes: &mut Array<Vector<E, NIn>>,
     in_offs: usize,
     weight_offs: usize,
     in_c_per_group: u32,
     stride_oc: usize,
+    #[comptime] base_v: usize,
 ) {
     let vector_size_in = input.vector_size();
-    let vector_size_out = sum.vector_size();
+    let block = lanes.len();
 
-    #[unroll]
-    for v in 0..vector_size_out {
-        let mut lanes = Vector::<E, NIn>::zero();
-        let weight_offs = weight_offs + v * stride_oc;
-
-        for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
-            let val = input[(in_offs + in_c as usize) / vector_size_in];
-
-            lanes += val * weight[(weight_offs + in_c as usize) / vector_size_in];
-        }
-
-        let mut channel = sum.extract(v);
+    for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
+        let val = input[(in_offs + in_c as usize) / vector_size_in];
 
         #[unroll]
-        for i in 0..vector_size_in {
-            channel += lanes.extract(i);
-        }
+        for j in 0..block {
+            let weight_offs = weight_offs + (base_v + j) * stride_oc + in_c as usize;
 
-        sum.insert(v, channel);
+            lanes[j] += val * weight[weight_offs / vector_size_in];
+        }
     }
 }
 

--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -16,6 +16,10 @@ use cubecl::{
 use cubecl::{num_traits::Zero, std::FastDivmod};
 use cubek::convolution::components::ConvSetupError;
 
+/// Wider than this and the accumulators stop fitting in registers: eight of them cost 8x the
+/// stores on AVX2, which outweighs every load the block saves.
+const CHANNEL_BLOCK: usize = 4;
+
 #[derive(CubeLaunch, CubeType, Clone)]
 pub(crate) struct ConvParam {
     pub stride: u32,
@@ -95,7 +99,7 @@ fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
     };
 
     let vector_size_in = input.vector_size();
-    let block = comptime![usize::min(4, vector_size_out)];
+    let block = comptime![usize::min(CHANNEL_BLOCK, vector_size_out)];
 
     if accumulate_lanes {
         #[unroll]
@@ -131,6 +135,7 @@ fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
             }
         }
     } else {
+        // Unread: `accumulate_per_step` sums into `sum`, and the loop still takes an accumulator.
         let mut lanes = Array::<Vector<E, NIn>>::new(1usize);
 
         kernel_loop(


### PR DESCRIPTION
Follow-up to #5545, on the same channel loop.

`accumulate_in_lanes` walked the output channels on the outside and the input channels on the
inside, and folded its lanes into `sum` at the end of every tap. Two costs follow from that
shape. The input vector is re-read for each output channel, so a channel step costs one input
load and one weight load per multiply-add; the machine has two load ports, so it can never
issue more than half a multiply-add per cycle. And the fold runs once per tap, so a 3x3 window
folds 144 times per output element, a cost that does not shrink as the channel loop gets
shorter and therefore dominates the narrow layers.

The loops are now the other way round, over a block of output channels at a time: one input
read serves the whole block, and the block's accumulators live across the whole kernel window,
so the fold happens once per block. For a 3x3 window at 8 lanes that is 16 folds per output
element instead of 144, and 1.25 loads per multiply-add instead of 2.

## Why the block is four

The block is the number of accumulators live at once, so it is bounded by the register file.
Eight does not fit on AVX2 and the accumulators spill:

| live accumulators | retired instructions | L1 stores | result |
|---|---|---|---|
| 1 (before) | 51.8e9 | 737M | baseline |
| 8 (all lanes) | 30.9e9 | 5431M | 20 to 35% slower |
| 4 | 22.5e9 | 403M | 1.74x faster |

The eight-accumulator form retires 40% fewer instructions than the baseline and is still
slower, because every accumulator update becomes a load, an add and a store. It is worth
saying out loud because the instruction count and the IR both endorse it: only the store
counter shows what is happening. Four is a literal today and wants to come from a hardware
property, since a machine with 32 vector registers should hold more.

## Where it applies

The gate from #5545 is unchanged, so this is still CPU only and GPUs compile what they did
before. Layers whose channel loop runs once, and depthwise convolutions, keep the old body.

## Results

cubecl-cpu on a Xeon E5-2620 v4 (AVX2, 537 GFLOPS peak), forced `Direct`, best of 3
interleaved rounds, GFLOPS:

| layer | batch 1 | batch 8 |
|---|---|---|
| ResNet r1 64-64 k3 | 62.3 -> 108.2 (1.74x) | 63.6 -> 110.8 (1.74x) |
| ResNet r2 128-128 k3 | 68.6 -> 103.2 (1.50x) | 70.3 -> 109.9 (1.56x) |
| ResNet r3 256-256 k3 | 72.5 -> 102.4 (1.41x) | 79.6 -> 113.9 (1.43x) |
| ResNet r4 512-512 k3 | 74.7 -> 100.0 (1.34x) | 91.5 -> 124.5 (1.36x) |
| 32-32 k3 | 40.3 -> 62.1 (1.54x) | 47.9 -> 105.7 (2.21x) |
| ResNet r1 256-64 k1 | 65.3 -> 88.0 (1.35x) | 75.9 -> 105.3 (1.39x) |
| ResNet r4 512-2048 k1 | 63.7 -> 72.0 (1.13x) | 75.0 -> 96.7 (1.29x) |

Convolution moves from 13.8% to 23% of the machine's compute peak. Nothing regresses; the
layers the gate excludes are unchanged. On an RTX 2060, 29 of 30 rows are within 1% on both
CUDA and Vulkan with identical checksums, and the 30th is a depthwise row whose own run to
run spread is 23 to 35%.

Hoisting costs 3 to 12% on 1x1 kernels, where there is one tap so no fold is saved but the
addresses are still re-derived per block. Those layers still gain 18 to 42%, and recovering it
needs a second code path, so it is left alone.

### ResNet-50

Same machine, `model-optimization`'s component ladder, batch 1, median of 5, each arm measured
warm from its own autotune cache:

| stage | before | after | |
|---|---|---|---|
| stem | 14.27 ms | 14.36 ms | flat |
| layer1 | 36.04 ms | 31.56 ms | -12.4% |
| layer2 | 49.17 ms | 44.85 ms | -8.8% |
| layer3 | 84.47 ms | 79.36 ms | -6.1% |
| layer4 | 64.88 ms | 62.76 ms | -3.3% |
| not attributed to a stage | 45.08 ms | 45.45 ms | flat |
| **whole model** | **294.11 ms** | **278.55 ms** | **-5.3%** |

Measurement resolution is 0.4%. The model gains less than the layers because autotune sends many
of these convolutions to im2col rather than `Direct`, so only some of them reach this kernel; the
per-layer table above forces `Direct` to isolate the kernel. `stem` is the control: its three
input channels fail the gate, so it must not move, and it does not.

### f16, and what it says about the block size

At f16 the vectorization is 16 wide, so the window is walked four times per output element
instead of twice: the same shape a 512-bit target would have at f32. It costs nothing.

| layer (batch 8) | before | after | |
|---|---|---|---|
| r1 64-64 k3 | 9.10 | 38.30 | 4.21x |
| r2 128-128 k3 | 15.30 | 42.30 | 2.76x |
| r3 256-256 k3 | 23.40 | 45.90 | 1.96x |
| r4 512-512 k3 | 34.00 | 52.00 | 1.53x |

The size of these is not transferable: f16 arithmetic round-trips through f32 on this hardware
and the fold is per operation, so removing folds removes conversions with them. The direction is
the point. Nothing regresses at f16 either.

## Numerics

Summation order changes across taps, so results move within float rounding. The conv2d suites
pass against the reference backend at default tolerance, on CPU and on wgpu.

---

Every machine this was measured on is AVX2, so the block of four is a floor established at 16
vector registers. A 32-register target should be able to hold more, and the re-derived addresses
cost more there too, since the window is walked once per block. Untested.
