### PR TITLE
fix(std): import vec! macro in layout.rs tests for no-std

### DIFF
--- a/crates/burn-std/src/tensor/layout.rs
+++ b/crates/burn-std/src/tensor/layout.rs
@@ -13,6 +13,7 @@
 //! pitched or tile-aligned allocation leaves under a dimension, which is enough
 //! to decide what order to iterate in.
 
+use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::Shape;

--- a/crates/burn-std/src/tensor/layout.rs
+++ b/crates/burn-std/src/tensor/layout.rs
@@ -13,7 +13,6 @@
 //! pitched or tile-aligned allocation leaves under a dimension, which is enough
 //! to decide what order to iterate in.
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::Shape;
@@ -105,6 +104,7 @@ pub fn is_contiguous_order(order: &[usize]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn contiguous_is_the_identity_order() {


### PR DESCRIPTION
Resolves #5638

### Problem

The no-std test job fails to compile `burn-std`:

```
error: cannot find macro `vec` in this scope
 --> crates/burn-std/src/tensor/layout.rs:209:30
```

`crates/burn-std/src/tensor/layout.rs` (added in #5625) imports `use alloc::vec::Vec;` but never imports the `vec!` macro. Its `#[cfg(test)]` module uses `vec![...]` (lines 115, 127, 197, 209), which only compiles when the std prelude is available, so `cargo test --no-default-features -p burn-std` fails.

### Change

Add `use alloc::vec;` next to the existing `use alloc::vec::Vec;`.

### Verification

Reproduced the failure locally with `cargo test --no-default-features --release -p burn-std` (4 `cannot find macro vec` errors) and confirmed the fix compiles and runs (168 unit tests pass).