### PR TITLE
fix(flex): validate gather_nd/scatter_nd coordinate bounds

### DIFF
--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -1032,7 +1032,7 @@ pub fn scatter_nd<
     for n in 0..num_indices {
         let mut base_offset = 0usize;
         for j in 0..k {
-            let idx_val = idx_data[n * k + j] as usize;
+            let idx_val = checked_index(idx_data[n * k + j], data_shape[j]);
             base_offset += idx_val * strides[j];
         }
 
@@ -1107,7 +1107,7 @@ pub fn gather_nd<E: Element + Pod + Default + Copy>(
     for n in 0..num_indices {
         let mut base_offset = 0usize;
         for j in 0..k {
-            let idx_val = idx_data[n * k + j] as usize;
+            let idx_val = checked_index(idx_data[n * k + j], data_shape[j]);
             base_offset += idx_val * strides[j];
         }
         let out_offset = n * slice_size;
@@ -1315,6 +1315,7 @@ pub fn scatter_or(
 mod tests {
     use super::*;
     use burn_backend::TensorData;
+    use burn_backend::tensor::IndexingUpdateOp;
 
     #[test]
     fn test_gather_with_i32_indices() {
@@ -1366,5 +1367,27 @@ mod tests {
                 "mismatch at output row {i} (src row {row_idx})"
             );
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "index 5 out of bounds for dimension of size 3")]
+    fn test_gather_nd_checks_each_coordinate_bound() {
+        let data = FlexTensor::from_data(TensorData::new(
+            (0..6).map(|i| i as f32).collect::<Vec<_>>(),
+            [2, 3],
+        ));
+        let indices = FlexTensor::from_data(TensorData::new(vec![0i64, 5], [1, 2]));
+
+        let _ = gather_nd::<f32>(data, indices);
+    }
+
+    #[test]
+    #[should_panic(expected = "index -1 out of bounds for dimension of size 3")]
+    fn test_scatter_nd_checks_negative_coordinate() {
+        let data = FlexTensor::from_data(TensorData::new(vec![0.0f32; 6], [2, 3]));
+        let indices = FlexTensor::from_data(TensorData::new(vec![0i64, -1], [1, 2]));
+        let values = FlexTensor::from_data(TensorData::new(vec![9.0f32], [1]));
+
+        let _ = scatter_nd::<f32>(data, indices, values, IndexingUpdateOp::Assign);
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Related Issues/PRs

Resolves #5606.

### Changes

`gather_nd` and `scatter_nd` in `burn-flex` did not validate each coordinate against the corresponding tensor dimension before computing the flattened offset.

As a result, an out-of-bounds coordinate could still resolve to a valid flat buffer position and silently access an element from another row. Negative indices were also cast directly to `usize`, resulting in misleading downstream panics.

This PR:

* Uses the existing `checked_index` helper for every coordinate in `gather_nd` and `scatter_nd`.
* Ensures both positive out-of-bounds and negative indices are rejected consistently.
* Adds regression tests covering these cases.

### Testing

Added regression tests for:

* An out-of-bounds coordinate in `gather_nd`.
* A negative coordinate in `scatter_nd`.

A validation PR was also run against the fork CI. Code quality, documentation, and Linux checks passed. The Windows crates job failed while compiling `wgpu-hal` because multiple incompatible versions of the `windows` / `windows-core` crates were present in the dependency graph; this failure is unrelated to the `burn-flex` changes in this PR.
