### PR TITLE
test(backend): cover empty-axis autodiff product reductions

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/aggregation.rs
+++ b/crates/burn-backend-tests/tests/autodiff/aggregation.rs
@@ -156,6 +156,24 @@ fn should_diff_sum_dim_empty_axis() {
 }
 
 #[test]
+fn should_diff_prod_dim_empty_axis() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::empty([3, 0], &device).require_grad();
+
+    let output = tensor.clone().prod_dim(1);
+    output
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0], [1.0], [1.0]]), false);
+
+    let grads = output.sum().backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    assert_eq!(grad.shape().dims(), [3, 0]);
+    grad.to_data()
+        .assert_eq(&TensorData::new(Vec::<FloatElem>::new(), [3, 0]), false);
+}
+
+#[test]
 fn should_diff_prod() {
     let device = AutodiffDevice::new();
     let tensor =


### PR DESCRIPTION
## Changes

Add autodiff coverage for `prod_dim` over a zero-length axis, asserting the product identity for each surviving output position and preservation of the empty input gradient shape. This extends coverage for [#5310](https://github.com/tracel-ai/burn/issues/5310); the underlying empty-axis production handling is already present on the base branch.

## Testing

- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features ndarray,std --test autodiff -- should_diff_prod_dim_empty_axis`
- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features flex,std --test autodiff -- should_diff_prod_dim_empty_axis`
- `cargo +1.96.1 test -p burn-backend-tests --no-default-features --features wgpu,std --test autodiff -- mask_select`
- `cargo +1.96.1 fmt --all -- --check`

The complete `cargo run-checks` audit was blocked by a RustSec advisory database network fetch.