### PR TITLE
test(cpu): cover avg_pool1d gradients with multiple channels

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/avgpool1d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/avgpool1d.rs
@@ -1,6 +1,52 @@
 use super::*;
 use burn_tensor::module::avg_pool1d;
-use burn_tensor::{Shape, Tolerance};
+use burn_tensor::{Shape, TensorData, Tolerance};
+
+#[test]
+fn test_avg_pool1d_backward_writes_every_channel() {
+    let device = AutodiffDevice::new();
+    let poison =
+        TestTensor::<2>::from_data(TensorData::new(vec![1234.5; 8192], [64, 128]), &device);
+    let _ = (poison.clone() * poison).sum().into_data();
+
+    for channels in [2, 4] {
+        let x = TestTensor::<3>::from_data(
+            TensorData::new(
+                (0..channels * 6)
+                    .map(|index| index as f32 * 0.1 + 0.5)
+                    .collect(),
+                [1, channels, 6],
+            ),
+            &device,
+        )
+        .require_grad();
+        let output = avg_pool1d(x.clone(), 3, 2, 1, true, false);
+        let grads = output.sum().backward();
+        let actual = x.grad(&grads).unwrap();
+        let expected = TestTensor::<3>::from_data(
+            TensorData::new(
+                vec![
+                    1.0 / 3.0,
+                    2.0 / 3.0,
+                    1.0 / 3.0,
+                    2.0 / 3.0,
+                    1.0 / 3.0,
+                    1.0 / 3.0,
+                ]
+                .into_iter()
+                .cycle()
+                .take(channels * 6)
+                .collect(),
+                [1, channels, 6],
+            ),
+            &device,
+        );
+
+        expected
+            .to_data()
+            .assert_approx_eq::<FloatElem>(&actual.into_data(), Tolerance::default());
+    }
+}
 
 #[test]
 fn test_avg_pool1d_simple() {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Fixes #5308

### Changes

Adds a focused CPU autodiff regression test for `avg_pool1d` with even channel counts. The test poisons allocator contents and verifies every input-gradient element against the pooling derivative.

### Testing

Focused CPU autodiff `avg_pool1d`, tensor `avg_pool1d`, tensor `max_pool1d`, formatting, and diff checks pass locally; the full `cargo run-checks` command was not run.

