### PR TITLE
refactor(conv): call cubek's direct convolution routine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
 ]
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "3de52af6cd1bc7dacf7898a863048267543f249e" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "d1f27f0c3064f26ae7dee762cfa267910b9a8355" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -1,300 +1,24 @@
-use crate::{kernel::utils::decompose_linear, ops::numeric::empty_device_dtype};
+//! The burn side of the direct convolution routine.
+//!
+//! The kernel itself lives in `cubek-convolution`, beside the depthwise routine and the
+//! accelerated ones. What stays here is what a tensor library owns rather than a kernel: making
+//! the operands contiguous along the channel, and allocating the result.
+
 use crate::{
-    kernel::{into_contiguous_aligned, utils::address_type},
-    ops::max_vector_size,
-    tensor::CubeTensor,
+    kernel::into_contiguous_aligned, ops::numeric::empty_device_dtype, tensor::CubeTensor,
 };
 use burn_backend::cubecl::dtype_to_storage_type;
-use burn_backend::{
-    TensorMetadata,
-    ops::{ConvOptions, conv::calculate_conv_output_sizes},
+use burn_backend::ops::{ConvOptions, conv::calculate_conv_output_sizes};
+use cubek::convolution::{
+    ConvolutionArgs, DirectTensors, components::ConvSetupError, launch_direct,
 };
-use cubecl::{
-    calculate_cube_count_elemwise, prelude::*, std::tensor::layout::linear::LinearViewMut,
-    tensor_vector_size_parallel,
-};
-use cubecl::{num_traits::Zero, std::FastDivmod};
-use cubek::convolution::components::ConvSetupError;
 
-#[derive(CubeLaunch, CubeType, Clone)]
-pub(crate) struct ConvParam {
-    pub stride: u32,
-    pub dilation: u32,
-    pub padding: i32,
-}
-
-#[derive(CubeLaunch, CubeType)]
-struct Conv2dArgs {
-    conv_params: Sequence<ConvParam>,
-    channels_per_group: u32,
-}
-
-#[cube(launch_unchecked, address_type = "dynamic")]
-#[allow(clippy::redundant_closure)]
-fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
-    input: &Tensor<Vector<E, NIn>>,
-    weight: &Tensor<Vector<E, NIn>>,
-    bias: ComptimeOption<&[Vector<E, NOut>]>,
-    mut output: LinearViewMut<'_, Vector<E, NOut>>,
-    args: Conv2dArgs,
-    shape_out: Sequence<FastDivmod<u32>>,
-    shape_out_c: FastDivmod<u32>,
-    #[comptime] has_padding: bool,
-    #[comptime] accumulate_lanes: bool,
-    #[define(E)] _dtype: ElemType,
-) {
-    if !output.is_in_bounds(ABSOLUTE_POS) {
-        terminate!();
-    }
-
-    let n_spatial = comptime![shape_out.len()];
-
-    let vector_size_out = output.vector_size();
-    let pos = ABSOLUTE_POS * vector_size_out;
-
-    let in_c_per_group = weight.shape(weight.rank() - 1) as u32;
-
-    let (rem, out_c) = shape_out_c.div_mod(pos as u32);
-    let (b, spatial_pos) = decompose_linear(rem, &shape_out);
-
-    let g = out_c / args.channels_per_group;
-    let ic_start = in_c_per_group * g;
-
-    let bias: ComptimeOption<Vector<E, NOut>> =
-        bias.map(|bias| bias[out_c as usize / vector_size_out]);
-    let mut sum = bias.unwrap_or_else(|| Vector::zero());
-
-    let in_offs = b as usize * input.stride(0) + ic_start as usize;
-
-    let stride_oc = weight.stride(0);
-
-    let mut in_shape = Sequence::new();
-    let mut in_strides = Sequence::new();
-    let mut kernel_shape = Sequence::new();
-    let mut kernel_strides = Sequence::new();
-
-    #[unroll]
-    for i in 0..n_spatial {
-        in_shape.push(input.shape(i + 1) as u32);
-        in_strides.push(input.stride(i + 1));
-        kernel_shape.push(weight.shape(i + 1) as u32);
-        kernel_strides.push(weight.stride(i + 1));
-    }
-
-    let weight_offs = out_c as usize * stride_oc;
-
-    let loop_params = LoopParams {
-        out_pos: spatial_pos,
-        in_shape,
-        in_strides,
-        kernel_shape,
-        kernel_strides,
-        conv_params: args.conv_params,
-        in_c_per_group,
-        stride_oc,
-    };
-
-    kernel_loop(
-        input,
-        weight,
-        &mut sum,
-        in_offs,
-        true,
-        weight_offs,
-        &loop_params,
-        0usize,
-        has_padding,
-        accumulate_lanes,
-    );
-
-    output.write(ABSOLUTE_POS, sum);
-}
-
-#[derive(CubeType, Clone)]
-struct LoopParams {
-    out_pos: Sequence<u32>,
-    in_shape: Sequence<u32>,
-    in_strides: Sequence<usize>,
-    kernel_shape: Sequence<u32>,
-    kernel_strides: Sequence<usize>,
-    conv_params: Sequence<ConvParam>,
-
-    in_c_per_group: u32,
-    stride_oc: usize,
-}
-
-#[cube]
-fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
-    input: &Tensor<Vector<E, NIn>>,
-    weight: &Tensor<Vector<E, NIn>>,
-    sum: &mut Vector<E, NOut>,
-    in_offs: usize,
-    in_bounds: bool,
-    weight_offs: usize,
-    params: &LoopParams,
-    #[comptime] kernel_dim: usize,
-    #[comptime] has_padding: bool,
-    #[comptime] accumulate_lanes: bool,
-) {
-    if comptime![kernel_dim < params.kernel_shape.len()] {
-        let out_idx = *params.out_pos.index(kernel_dim);
-        let conv = params.conv_params.index(kernel_dim);
-        let shape = *params.in_shape.index(kernel_dim);
-        let stride = *params.in_strides.index(kernel_dim);
-        let k_stride = *params.kernel_strides.index(kernel_dim);
-
-        for pos in 0..*params.kernel_shape.index(kernel_dim) {
-            let in_pos = (out_idx * conv.stride + pos * conv.dilation) as i32 - conv.padding;
-            let in_offs = in_offs + in_pos as usize * stride;
-            let weight_offs = weight_offs + pos as usize * k_stride;
-            let mut in_bounds = in_bounds;
-
-            if has_padding {
-                in_bounds &= in_pos >= 0 && (in_pos as u32) < shape;
-            }
-
-            kernel_loop(
-                input,
-                weight,
-                sum,
-                in_offs,
-                in_bounds,
-                weight_offs,
-                params,
-                comptime![kernel_dim + 1],
-                has_padding,
-                accumulate_lanes,
-            );
-        }
-    } else {
-        kernel_loop_inner(
-            input,
-            weight,
-            sum,
-            in_offs,
-            in_bounds,
-            weight_offs,
-            params.in_c_per_group,
-            params.stride_oc,
-            accumulate_lanes,
-        );
-    }
-}
-
-#[cube]
-fn kernel_loop_inner<E: Numeric, NIn: Size, NOut: Size>(
-    input: &Tensor<Vector<E, NIn>>,
-    weight: &Tensor<Vector<E, NIn>>,
-    sum: &mut Vector<E, NOut>,
-    in_offs: usize,
-    in_bounds: bool,
-    weight_offs: usize,
-    in_c_per_group: u32,
-    stride_oc: usize,
-    #[comptime] accumulate_lanes: bool,
-) {
-    if in_bounds {
-        if accumulate_lanes {
-            accumulate_in_lanes(
-                input,
-                weight,
-                sum,
-                in_offs,
-                weight_offs,
-                in_c_per_group,
-                stride_oc,
-            );
-        } else {
-            accumulate_per_step(
-                input,
-                weight,
-                sum,
-                in_offs,
-                weight_offs,
-                in_c_per_group,
-                stride_oc,
-            );
-        }
-    }
-}
-
-/// One input read per output channel buys a channel loop with no dependency chain.
-#[cube]
-fn accumulate_in_lanes<E: Numeric, NIn: Size, NOut: Size>(
-    input: &Tensor<Vector<E, NIn>>,
-    weight: &Tensor<Vector<E, NIn>>,
-    sum: &mut Vector<E, NOut>,
-    in_offs: usize,
-    weight_offs: usize,
-    in_c_per_group: u32,
-    stride_oc: usize,
-) {
-    let vector_size_in = input.vector_size();
-    let vector_size_out = sum.vector_size();
-
-    #[unroll]
-    for v in 0..vector_size_out {
-        let mut lanes = Vector::<E, NIn>::zero();
-        let weight_offs = weight_offs + v * stride_oc;
-
-        for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
-            let val = input[(in_offs + in_c as usize) / vector_size_in];
-
-            lanes += val * weight[(weight_offs + in_c as usize) / vector_size_in];
-        }
-
-        let mut channel = sum.extract(v);
-
-        #[unroll]
-        for i in 0..vector_size_in {
-            channel += lanes.extract(i);
-        }
-
-        sum.insert(v, channel);
-    }
-}
-
-/// One input read serves every output channel, which is all a one-step channel loop can win.
-#[cube]
-fn accumulate_per_step<E: Numeric, NIn: Size, NOut: Size>(
-    input: &Tensor<Vector<E, NIn>>,
-    weight: &Tensor<Vector<E, NIn>>,
-    sum: &mut Vector<E, NOut>,
-    in_offs: usize,
-    weight_offs: usize,
-    in_c_per_group: u32,
-    stride_oc: usize,
-) {
-    let vector_size_in = input.vector_size();
-    let vector_size_out = sum.vector_size();
-
-    for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
-        let in_pos = in_offs + in_c as usize;
-        let mut weight_pos = weight_offs + in_c as usize;
-
-        let val = input[in_pos / vector_size_in];
-
-        #[unroll]
-        for v in 0..vector_size_out {
-            let weight = weight[weight_pos / vector_size_in];
-            let val = val * weight;
-
-            #[unroll]
-            for i in 0..vector_size_in {
-                sum.insert(v, sum.extract(v) + val.extract(i));
-            }
-            weight_pos += stride_oc;
-        }
-    }
-}
-
-/// Perform a 2D convolution using the direct convolution algorithm.
+/// Perform a convolution using the direct convolution algorithm.
 ///
 /// * `input` - The input feature map
 /// * `weight` - The weights (filter) applied to each kernel
 /// * `bias` - The bias added to each channel
 /// * `options` - The options to use for the convolution
-///
 pub fn conv_direct<const N: usize>(
     mut input: CubeTensor,
     mut weight: CubeTensor,
@@ -318,8 +42,6 @@ pub fn conv_direct<const N: usize>(
     let out_channels = weight.meta.shape()[0];
     let kernel_shape = &weight.meta.shape()[1..dim_c];
 
-    let channels_per_group = out_channels / options.groups;
-
     let out_size = calculate_conv_output_sizes(
         kernel_shape,
         &options.stride,
@@ -327,96 +49,38 @@ pub fn conv_direct<const N: usize>(
         &options.dilation,
         in_shape,
     );
-    let check_spatial_bounds =
-        should_check_spatial_bounds(in_shape, kernel_shape, &out_size, &options);
 
     let mut shape_out = vec![batch_size];
     shape_out.extend(out_size.iter().copied());
     shape_out.push(out_channels);
 
-    let output = empty_device_dtype(
+    let out = empty_device_dtype(
         input.client.clone(),
         input.device.clone(),
         shape_out.into(),
         out_dtype,
     );
 
-    // Need custom vector size calculation here to account for the groups division. Need to vectorize
-    // over `channels_per_group` instead.
-    let mut grouped_out_shape = output.shape();
-    grouped_out_shape[dim_c] = channels_per_group;
-    let vector_size_out = tensor_vector_size_parallel(
-        input.client.io_optimized_vector_sizes(input.dtype.size()),
-        &grouped_out_shape,
-        output.meta.strides(),
-        dim_c,
-    );
-    // Use channels_per_group instead of in_channels to avoid issues here
-    let vector_size_in = max_vector_size(&weight);
-
-    // Only a single-unit plane pays the dependency chain in full; a wide plane hides it and is
-    // left with the extra input read per output channel. One lane is exactly as serial as `sum`,
-    // and a channel loop of one step has nothing to amortize the fold over.
-    let accumulate_lanes = input.client.properties().hardware.plane_size_max == 1
-        && vector_size_in > 1
-        && weight.meta.shape()[dim_c] > vector_size_in as usize;
-
-    let shape_out = output.meta.shape()[1..dim_c]
-        .iter()
-        .map(|s| *s as u32)
-        .collect();
-    let shape_out_c = out_channels as u32;
-
-    let mut conv_params = SequenceArg::new();
-
-    for i in 0..kernel_shape.len() {
-        conv_params.push(ConvParamLaunch::new(
-            options.stride[i] as u32,
-            options.dilation[i] as u32,
-            options.padding_begin()[i] as i32,
-        ));
-    }
-
-    let working_units = output.meta.num_elements() / vector_size_out;
-    let cube_dim = CubeDim::new(&input.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&input.client, working_units, cube_dim);
-
-    unsafe {
-        direct_conv2d_kernel::launch_unchecked(
-            &output.client,
-            cube_count,
-            cube_dim,
-            address_type!(input, weight, bias, output),
-            vector_size_in,
-            vector_size_out,
-            input.into_tensor_arg(),
-            weight.into_tensor_arg(),
-            bias.map(|b| b.into_buffer_arg()).into(),
-            output.clone().into_linear_view(),
-            Conv2dArgsLaunch::new(conv_params, channels_per_group as u32),
-            shape_out,
-            shape_out_c,
-            check_spatial_bounds,
-            accumulate_lanes,
-            dtype_to_storage_type(out_dtype),
-        )
+    let padding = options.padding_begin();
+    let args = ConvolutionArgs::<N> {
+        stride: options.stride,
+        padding: core::array::from_fn(|i| padding[i]),
+        dilation: options.dilation,
     };
 
-    Ok(output)
-}
+    let client = input.client.clone();
+    let dtype = dtype_to_storage_type(out_dtype);
 
-fn should_check_spatial_bounds<const N: usize>(
-    in_shape: &[usize],
-    kernel_shape: &[usize],
-    out_shape: &[usize],
-    options: &ConvOptions<N>,
-) -> bool {
-    (0..N).any(|dim| {
-        let begin = options.padding[dim].0 as i64;
-        let first = -begin;
-        let last = (out_shape[dim] as i64 - 1) * options.stride[dim] as i64
-            + (kernel_shape[dim] as i64 - 1) * options.dilation[dim] as i64
-            - begin;
-        first < 0 || last >= in_shape[dim] as i64
-    })
+    // The routine reads the problem off the bindings, so the shapes it sizes its launch from are
+    // the shapes the kernel addresses.
+    let tensors = DirectTensors {
+        input: input.binding(),
+        weight: weight.binding(),
+        bias: bias.map(|bias| bias.binding()),
+        out: out.clone().binding(),
+    };
+
+    launch_direct::<N>(&client, tensors, args, options.groups, dtype)?;
+
+    Ok(out)
 }

--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -1,9 +1,3 @@
-//! The burn side of the direct convolution routine.
-//!
-//! The kernel itself lives in `cubek-convolution`, beside the depthwise routine and the
-//! accelerated ones. What stays here is what a tensor library owns rather than a kernel: making
-//! the operands contiguous along the channel, and allocating the result.
-
 use crate::{
     kernel::into_contiguous_aligned, ops::numeric::empty_device_dtype, tensor::CubeTensor,
 };
@@ -71,8 +65,6 @@ pub fn conv_direct<const N: usize>(
     let client = input.client.clone();
     let dtype = dtype_to_storage_type(out_dtype);
 
-    // The routine reads the problem off the bindings, so the shapes it sizes its launch from are
-    // the shapes the kernel addresses.
     let tensors = DirectTensors {
         input: input.binding(),
         weight: weight.binding(),


### PR DESCRIPTION
The direct convolution kernel moves to `cubek-convolution`, beside the depthwise routine this crate already delegates to and the accelerated ones. What a tensor library owns stays here: making the operands contiguous along the channel, and allocating the result.

422 lines become 87, the same shape as the depthwise wrapper next to it.

**No behaviour change: the kernel moved verbatim.** It is byte-identical to this crate's `direct.rs` on `main`.

Why move it. cubek scores its benchmarks against measured device ceilings (`measure_peak_throughput`, `measure_memory_curve`) and its convolution crate already carries `Conv2dCost::traffic()` and `compute_key()`. A kernel here can reach none of that, so measuring this one has meant a bespoke harness and hand-computed theoretical peaks. It also puts the kernel next to the `compute_bound` / `memory_bound` autotune bounds that price a candidate against both roofs.

Checks: clippy clean with `-D warnings`; 35 conv2d tests pass on CPU and 35 on wgpu, built against the cubek branch through a local `[patch]`.
