### PR TITLE
fix(linalg): add autotune feature propagation

### DIFF
--- a/crates/burn-linalg/Cargo.toml
+++ b/crates/burn-linalg/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 default = ["burn-core/default", "flex", "cubecl-backend", "fusion", "std"]
 std = ["burn-core/std", "burn-std/std", "burn-fusion?/std"]
 tracing = ["burn-core/tracing", "burn-fusion?/tracing"]
+autotune = ["burn-core/autotune", "burn-cubecl?/autotune"]
 
 cubecl-backend = ["burn-cubecl"]
 fusion = ["burn-fusion", "burn-core/fusion"]

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -84,7 +84,10 @@ pub(crate) fn handle_backend_tests(
         test_args.extend(["--features", "std"])
     }
 
-    let linalg_test_args = test_args.clone();
+    let mut linalg_test_args = test_args.clone();
+    if !matches!(context, Context::NoStd) {
+        linalg_test_args.extend(["--features", "autotune"]);
+    }
 
     if matches!(backend, TestBackend::Cuda) {
         // Collective (all-reduce) tests require a CUDA build with NCCL, which the CI runner


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

#5572

### Changes

Added missing autotune feature for propagation in `burn-linalg`
