### PR TITLE
fix(flex): honor asymmetric padding in conv3d

### DIFF
--- a/crates/burn-flex/src/ops/module.rs
+++ b/crates/burn-flex/src/ops/module.rs
@@ -251,6 +251,7 @@ impl ModuleOps<Flex> for Flex {
         bias: Option<FloatTensor<Flex>>,
         options: ConvOptions<3>,
     ) -> FloatTensor<Flex> {
+        let (x, options) = pad_asymmetric_conv_input::<Flex, 3>(x, options);
         match x.dtype() {
             DType::F32 => conv::conv3d_f32(x, weight, bias, &options),
             DType::F64 => conv::conv3d_f64(x, weight, bias, &options),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Fixes https://github.com/tracel-ai/burn/issues/5601

### Changes

`Flex::conv3d` dropped end padding. `conv1d` and `conv2d` already call `pad_asymmetric_conv_input` first; `conv3d` did not, and the kernel only reads `padding_begin()`.

This adds the same helper call at the top of `Flex::conv3d`:

```rust
let (x, options) = pad_asymmetric_conv_input::<Flex, 3>(x, options);
```


### Testing

**Issue repro** (`cargo test` locally: pass):

```rust
let x = FlexTensor::from_data(TensorData::new(vec![1.0f32, 2.0, 3.0, 4.0], vec![1, 1, 1, 1, 4]));
let w = FlexTensor::from_data(TensorData::new(vec![1.0f32, 1.0], vec![1, 1, 1, 1, 2]));
let opts = ConvOptions::<3>::new_with_padding([1, 1, 1], [(0, 0), (0, 0), (0, 1)], [1, 1, 1], 1);
let out = Flex::conv3d(x, w, None, opts);
// shape [1,1,1,1,4], values [3, 5, 7, 4]
```