### PR TITLE
fix: correct Flex average-pooling gradients with ceil mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
 ]
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=3de52af6cd1bc7dacf7898a863048267543f249e#3de52af6cd1bc7dacf7898a863048267543f249e"
+source = "git+https://github.com/tracel-ai/cubek?rev=a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad#a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "3de52af6cd1bc7dacf7898a863048267543f249e" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "a1dff403c3a6a8ac2f0f03fd5a4afd05d94e45ad" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend-tests/tests/autodiff/avgpool2d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/avgpool2d.rs
@@ -1,6 +1,47 @@
 use super::*;
 use burn_tensor::module::avg_pool2d;
-use burn_tensor::{Shape, Tolerance};
+use burn_tensor::{Shape, TensorData, Tolerance};
+
+#[test]
+fn test_avg_pool2d_ceil_mode_nonuniform_gradient() {
+    let device = AutodiffDevice::new();
+    for count_include_pad in [true, false] {
+        for (width, kernel, padding, upstream, expected) in [
+            (5, 2, 0, vec![2.0, 4.0, 8.0], vec![1.0, 1.0, 2.0, 2.0, 8.0]),
+            (
+                3,
+                3,
+                1,
+                vec![6.0, 8.0],
+                if count_include_pad {
+                    vec![2.0, 2.0, 4.0]
+                } else {
+                    vec![3.0, 3.0, 8.0]
+                },
+            ),
+        ] {
+            let x = TestTensor::<4>::ones([1, 1, 1, width], &device).require_grad();
+            let output = avg_pool2d(
+                x.clone(),
+                [1, kernel],
+                [1, kernel],
+                [0, padding],
+                count_include_pad,
+                true,
+            );
+            let upstream =
+                TestTensor::from_data(TensorData::new(upstream, output.shape()), &device);
+            let grads = (output * upstream).backward();
+            x.grad(&grads)
+                .unwrap()
+                .into_data()
+                .assert_approx_eq::<FloatElem>(
+                    &TensorData::new(expected, [1, 1, 1, width]),
+                    Tolerance::default(),
+                );
+        }
+    }
+}
 
 #[test]
 fn test_avg_pool2d_simple() {

--- a/crates/burn-flex/src/ops/pool.rs
+++ b/crates/burn-flex/src/ops/pool.rs
@@ -1403,7 +1403,6 @@ where
     let [kernel_d, kernel_h, kernel_w] = kernel_size;
     let [stride_d, stride_h, stride_w] = stride;
     let [pad_d, pad_h, pad_w] = padding;
-    let kernel_volume = kernel_d * kernel_h * kernel_w;
 
     let grad_shape = grad.layout().shape();
     let out_d = grad_shape[2];
@@ -1446,7 +1445,10 @@ where
                         }
 
                         let divisor = if count_include_pad {
-                            kernel_volume
+                            let pd_len = padded_len_avgpool(od, kernel_d, stride_d, pad_d, in_d);
+                            let ph_len = padded_len_avgpool(oh, kernel_h, stride_h, pad_h, in_h);
+                            let pw_len = padded_len_avgpool(ow, kernel_w, stride_w, pad_w, in_w);
+                            (pd_len * ph_len * pw_len).max(1)
                         } else {
                             count.max(1)
                         };
@@ -1832,6 +1834,31 @@ mod tests {
         assert_eq!(grad_data[13], 1.0);
         assert_eq!(grad_data[15], 1.0);
         assert_eq!(grad_data[0], 0.0);
+    }
+
+    #[test]
+    fn test_avg_pool3d_backward_ceil_mode_nonuniform_gradient() {
+        for count_include_pad in [true, false] {
+            let x = FlexTensor::from_data(TensorData::new(vec![1.0f32; 27], [1, 1, 3, 3, 3]));
+            let output = avg_pool3d_f32(x.clone(), [3; 3], [3; 3], [1; 3], count_include_pad, true);
+            let grad = FlexTensor::from_data(TensorData::new(
+                vec![216.0f32, 144.0, 144.0, 96.0, 144.0, 96.0, 96.0, 64.0],
+                output.layout().shape().clone(),
+            ));
+            let actual =
+                avg_pool3d_backward_f32(x, grad, [3; 3], [3; 3], [1; 3], count_include_pad);
+            let actual: Vec<f32> = actual.into_data().try_into_vec().unwrap();
+            let expected = if count_include_pad {
+                vec![8.0; 27]
+            } else {
+                vec![
+                    27.0, 27.0, 36.0, 27.0, 27.0, 36.0, 36.0, 36.0, 48.0, 27.0, 27.0, 36.0, 27.0,
+                    27.0, 36.0, 36.0, 36.0, 48.0, 36.0, 36.0, 48.0, 36.0, 36.0, 48.0, 48.0, 48.0,
+                    64.0,
+                ]
+            };
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR. (no changes needed)

### Related Issues/PRs

Fixes #5604 by using the same clipped padded divisor in average-pooling backward as in forward when ceil_mode is enabled.

### Changes

Changed files:

- crates/burn-flex/src/ops/pool.rs: corrected the shared 3D backward divisor, which also fixes 2D backward. Added coverage for windows overhanging all three spatial dimensions
- crates/burn-backend-tests/tests/autodiff/avgpool2d.rs: added coverage for the reported width-five example, actual padding, both count_include_pad settings, and nonuniform upstream gradients
- Cargo.toml and Cargo.lock: temporarily pin CubeK to the fix in tracel-ai/cubek#648

### Testing

- Verified the regressions fail with the old divisor and pass with the fix on Flex. Upstream gradients [2, 4, 8] now produce the expected input gradient [1, 1, 2, 2, 8]. The same failure was reproduced on CUDA and now passes with the updated CubeK pin
- CUDA pooling tests passed against the pinned CubeK commit
- Focused pooling and autodiff tests passed, including checkpointing
- Mandatory cargo run-checks passed

### Caveats

I've found that the same defect also exists in Burn’s previous CubeK pin, namely across all CUDA, ROCm, WGPU, and CubeCL CPU backends.

I ran the new test with the CUDA backend and reproduced the issue there before fixing it in CubeK. This PR now temporarily pins that CubeK fix, and the CUDA pooling tests pass with it.

I've submitted tracel-ai/cubek#648 to fix the issue there. I'll keep this PR as a draft until it is merged and will update the pin to the final commit SHA before opening it for final review.