### PR TITLE
fix(cubecl): update cubek to fix sums over overlapping views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2357,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2573,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "darling 0.24.1",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "darling 0.24.1",
  "inflections",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "derive-new",
  "serde",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
 ]
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2891,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
+source = "git+https://github.com/tracel-ai/cubek?rev=7ace55c61fcba35e36f40d4c40caadc4bd7da613#7ace55c61fcba35e36f40d4c40caadc4bd7da613"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
 ]
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2891,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=d1f27f0c3064f26ae7dee762cfa267910b9a8355#d1f27f0c3064f26ae7dee762cfa267910b9a8355"
+source = "git+https://github.com/tracel-ai/cubek?rev=05da3b672e1a3ff5adafff36287dceac7fdfe377#05da3b672e1a3ff5adafff36287dceac7fdfe377"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "d1f27f0c3064f26ae7dee762cfa267910b9a8355" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "05da3b672e1a3ff5adafff36287dceac7fdfe377" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,11 +225,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "05da3b672e1a3ff5adafff36287dceac7fdfe377" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "7ace55c61fcba35e36f40d4c40caadc4bd7da613" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

https://github.com/tracel-ai/cubek/pull/649

CI failure:
```
failures:

---- tensor::float::ops::aggregation::test_sum_overlapping_unfold stdout ----

thread 'tensor::float::ops::aggregation::test_sum_overlapping_unfold' (35495) panicked at crates/burn-backend-tests/tests/common/../tensor/float/ops/aggregation.rs:632:10:
Tensors are not eq:
  => Position 0: 15 != 12


failures:
    tensor::float::ops::aggregation::test_sum_overlapping_unfold

test result: FAILED. 1516 passed; 1 failed; 12 ignored; 0 measured; 0 filtered out; finished in 138.66s
```

### Changes

Update cubek revision with the fix

### Testing

`test_sum_overlapping_unfold` now passes
