### PR TITLE
fix(flex): propagate NaN through relu and clamp_min/clamp_max

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/relu.rs
+++ b/crates/burn-backend-tests/tests/autodiff/relu.rs
@@ -25,3 +25,20 @@ fn should_diff_relu() {
         .to_data()
         .assert_eq(&TensorData::from([[15.0, 13.0], [-2.0, 39.0]]), false);
 }
+
+// A NaN output must not have its gradient zeroed: the trait default masks on
+// `output <= 0`, which is false for NaN. See issue #5609.
+#[test]
+fn should_keep_grad_for_nan_relu_output() {
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([f32::NAN, -1.0, 2.0]), &device).require_grad();
+
+    let grads = activation::relu(tensor.clone()).sum().backward();
+
+    tensor
+        .grad(&grads)
+        .unwrap()
+        .to_data()
+        .assert_eq(&TensorData::from([1.0, 0.0, 1.0]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/activation/relu.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/relu.rs
@@ -23,3 +23,27 @@ fn test_relu_d1() {
         Tolerance::absolute(1e-6),
     );
 }
+
+// All burn backends should propagate NaN through relu. See issue #5609.
+#[test]
+fn test_relu_nan_propagation() {
+    let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 0.0, 2.0]);
+
+    let output = activation::relu(tensor).into_data().convert::<f32>();
+    let values = output.as_slice::<f32>().unwrap();
+
+    assert!(values[0].is_nan());
+    assert_eq!(values[1..], [0.0, 0.0, 2.0]);
+}
+
+#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[test]
+fn test_relu_nan_propagation_f64() {
+    let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 0.0, 2.0]).cast(burn_tensor::DType::F64);
+
+    let output = activation::relu(tensor).into_data();
+    let values = output.as_slice::<f64>().unwrap();
+
+    assert!(values[0].is_nan());
+    assert_eq!(values[1..], [0.0, 0.0, 2.0]);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/clamp.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/clamp.rs
@@ -79,3 +79,59 @@ fn clamp_min_max_vec_should_compile() {
         false,
     );
 }
+
+// All burn backends should propagate NaN through clamp_min / clamp_max. See issue #5609.
+#[test]
+fn clamp_min_nan_propagation() {
+    let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 2.0]);
+
+    let output = tensor.clamp_min(0.0).into_data().convert::<f32>();
+    let values = output.as_slice::<f32>().unwrap();
+
+    assert!(values[0].is_nan());
+    assert_eq!(values[1..], [0.0, 2.0]);
+}
+
+#[test]
+fn clamp_max_nan_propagation() {
+    let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 2.0]);
+
+    let output = tensor.clamp_max(1.0).into_data().convert::<f32>();
+    let values = output.as_slice::<f32>().unwrap();
+
+    assert!(values[0].is_nan());
+    assert_eq!(values[1..], [-1.0, 1.0]);
+}
+
+// Two-sided clamp still maps NaN to a bound on the cube backends (verified failing on
+// CUDA), so this stays on the CPU backends until that is fixed separately.
+#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[test]
+fn clamp_nan_propagation() {
+    for dtype in [burn_tensor::DType::F32, burn_tensor::DType::F64] {
+        let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 2.0]).cast(dtype);
+
+        let output = tensor.clamp(0.0, 1.0).into_data().convert::<f32>();
+        let values = output.as_slice::<f32>().unwrap();
+
+        assert!(values[0].is_nan(), "{dtype:?}");
+        assert_eq!(values[1..], [0.0, 1.0], "{dtype:?}");
+    }
+}
+
+#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[test]
+fn clamp_min_max_nan_propagation_f64() {
+    let tensor = TestTensor::<1>::from([f32::NAN, -1.0, 2.0]).cast(burn_tensor::DType::F64);
+
+    for (output, expected) in [
+        (tensor.clone().clamp_min(0.0), [0.0, 2.0]),
+        (tensor.clamp_max(1.0), [-1.0, 1.0]),
+    ] {
+        let output = output.into_data();
+        let values = output.as_slice::<f64>().unwrap();
+
+        assert!(values[0].is_nan());
+        assert_eq!(values[1..], expected);
+    }
+}

--- a/crates/burn-flex/src/ops/activation.rs
+++ b/crates/burn-flex/src/ops/activation.rs
@@ -21,7 +21,13 @@ use crate::{Flex, FlexTensor, Layout};
 
 impl ActivationOps<Flex> for Flex {
     fn relu(tensor: FloatTensor<Flex>) -> FloatTensor<Flex> {
-        unary_op(tensor, |x: f32| x.max(0.0), |x: f64| x.max(0.0))
+        // `max` returns the non-NaN operand, which would map NaN to the bound.
+        // Test `is_nan` first so NaN propagates, as PyTorch does.
+        unary_op(
+            tensor,
+            |x: f32| if x.is_nan() || x > 0.0 { x } else { 0.0 },
+            |x: f64| if x.is_nan() || x > 0.0 { x } else { 0.0 },
+        )
     }
 
     fn relu_backward(output: FloatTensor<Flex>, grad: FloatTensor<Flex>) -> FloatTensor<Flex> {
@@ -1516,5 +1522,22 @@ mod tests {
         let t = flex_f32(vec![1.0, 2.0, 3.0, 4.0], &[1, 4]);
         let gamma = flex_f64(vec![1.0; 4], &[4]);
         let _ = crate::ops::activation::layer_norm(t, gamma, None, 1e-5);
+    }
+
+    // Regression test for #5609. `f32::max` / `f64::max` return the non-NaN
+    // operand, so relu used to map NaN to 0 and hide divergence during training.
+    #[test]
+    fn test_relu_propagates_nan() {
+        use burn_backend::ops::ActivationOps;
+
+        let t = FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 0.0, 2.0]));
+        let out: Vec<f32> = crate::Flex::relu(t).into_data().try_into_vec().unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [0.0, 0.0, 2.0]);
+
+        let t = FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 0.0, 2.0]));
+        let out: Vec<f64> = crate::Flex::relu(t).into_data().try_into_vec().unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [0.0, 0.0, 2.0]);
     }
 }

--- a/crates/burn-flex/src/ops/activation.rs
+++ b/crates/burn-flex/src/ops/activation.rs
@@ -22,7 +22,9 @@ use crate::{Flex, FlexTensor, Layout};
 impl ActivationOps<Flex> for Flex {
     fn relu(tensor: FloatTensor<Flex>) -> FloatTensor<Flex> {
         // `max` returns the non-NaN operand, which would map NaN to the bound.
-        // Test `is_nan` first so NaN propagates, as PyTorch does.
+        // Testing `is_nan` first lets NaN propagate, as PyTorch does. `!(x <= 0.0)` is
+        // equivalent and compiles to the same code, but trips
+        // `clippy::neg_cmp_op_on_partial_ord`.
         unary_op(
             tensor,
             |x: f32| if x.is_nan() || x > 0.0 { x } else { 0.0 },
@@ -1522,22 +1524,5 @@ mod tests {
         let t = flex_f32(vec![1.0, 2.0, 3.0, 4.0], &[1, 4]);
         let gamma = flex_f64(vec![1.0; 4], &[4]);
         let _ = crate::ops::activation::layer_norm(t, gamma, None, 1e-5);
-    }
-
-    // Regression test for #5609. `f32::max` / `f64::max` return the non-NaN
-    // operand, so relu used to map NaN to 0 and hide divergence during training.
-    #[test]
-    fn test_relu_propagates_nan() {
-        use burn_backend::ops::ActivationOps;
-
-        let t = FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 0.0, 2.0]));
-        let out: Vec<f32> = crate::Flex::relu(t).into_data().try_into_vec().unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [0.0, 0.0, 2.0]);
-
-        let t = FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 0.0, 2.0]));
-        let out: Vec<f64> = crate::Flex::relu(t).into_data().try_into_vec().unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [0.0, 0.0, 2.0]);
     }
 }

--- a/crates/burn-flex/src/ops/activation.rs
+++ b/crates/burn-flex/src/ops/activation.rs
@@ -33,12 +33,14 @@ impl ActivationOps<Flex> for Flex {
     }
 
     fn relu_backward(output: FloatTensor<Flex>, grad: FloatTensor<Flex>) -> FloatTensor<Flex> {
-        // grad * (output > 0): zero the gradient where output was zero
+        // Zero the gradient where the output was zero, but keep it for a NaN output:
+        // the trait default masks with `float_lower_equal_elem(output, 0)`, which is
+        // false for NaN.
         binary_op(
             output,
             grad,
-            |out: f32, g| if out > 0.0 { g } else { 0.0 },
-            |out: f64, g| if out > 0.0 { g } else { 0.0 },
+            |out: f32, g| if out.is_nan() || out > 0.0 { g } else { 0.0 },
+            |out: f64, g| if out.is_nan() || out > 0.0 { g } else { 0.0 },
             None,
         )
     }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -617,20 +617,24 @@ impl FloatTensorOps<Flex> for Flex {
     fn float_clamp_min(tensor: FloatTensor<Flex>, min: Scalar) -> FloatTensor<Flex> {
         let min32 = min.to_f32().unwrap();
         let min64 = min.to_f64().unwrap();
+        // `max` returns the non-NaN operand, which would map NaN to the bound.
+        // Test `is_nan` first so NaN propagates, as PyTorch does.
         unary::unary_op(
             tensor,
-            move |x: f32| x.max(min32),
-            move |x: f64| x.max(min64),
+            move |x: f32| if x.is_nan() || x > min32 { x } else { min32 },
+            move |x: f64| if x.is_nan() || x > min64 { x } else { min64 },
         )
     }
 
     fn float_clamp_max(tensor: FloatTensor<Flex>, max: Scalar) -> FloatTensor<Flex> {
         let max32 = max.to_f32().unwrap();
         let max64 = max.to_f64().unwrap();
+        // `min` returns the non-NaN operand, which would map NaN to the bound.
+        // Test `is_nan` first so NaN propagates, as PyTorch does.
         unary::unary_op(
             tensor,
-            move |x: f32| x.min(max32),
-            move |x: f64| x.min(max64),
+            move |x: f32| if x.is_nan() || x < max32 { x } else { max32 },
+            move |x: f64| if x.is_nan() || x < max64 { x } else { max64 },
         )
     }
 
@@ -1326,5 +1330,66 @@ mod tests {
         let device = crate::FlexDevice;
         let t = Flex::float_random(shape, dist, &device, FloatDType::F16);
         assert_eq!(t.dtype(), DType::F16);
+    }
+
+    // Regression tests for #5609. `f32::max` / `f32::min` return the non-NaN
+    // operand, so clamp_min / clamp_max used to replace NaN with the bound while
+    // `float_clamp` (built on `f32::clamp`) propagated it.
+    #[test]
+    fn test_float_clamp_min_propagates_nan() {
+        use burn_backend::Scalar;
+        use burn_backend::ops::FloatTensorOps;
+
+        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
+        let out: Vec<f32> = Flex::float_clamp_min(t, Scalar::from(0.0f32))
+            .into_data()
+            .try_into_vec()
+            .unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [0.0, 2.0]);
+
+        let t = crate::FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 2.0]));
+        let out: Vec<f64> = Flex::float_clamp_min(t, Scalar::from(0.0f64))
+            .into_data()
+            .try_into_vec()
+            .unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [0.0, 2.0]);
+    }
+
+    #[test]
+    fn test_float_clamp_max_propagates_nan() {
+        use burn_backend::Scalar;
+        use burn_backend::ops::FloatTensorOps;
+
+        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
+        let out: Vec<f32> = Flex::float_clamp_max(t, Scalar::from(1.0f32))
+            .into_data()
+            .try_into_vec()
+            .unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [-1.0, 1.0]);
+
+        let t = crate::FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 2.0]));
+        let out: Vec<f64> = Flex::float_clamp_max(t, Scalar::from(1.0f64))
+            .into_data()
+            .try_into_vec()
+            .unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [-1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_float_clamp_propagates_nan() {
+        use burn_backend::Scalar;
+        use burn_backend::ops::FloatTensorOps;
+
+        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
+        let out: Vec<f32> = Flex::float_clamp(t, Scalar::from(0.0f32), Scalar::from(1.0f32))
+            .into_data()
+            .try_into_vec()
+            .unwrap();
+        assert!(out[0].is_nan());
+        assert_eq!(out[1..], [0.0, 1.0]);
     }
 }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -618,7 +618,7 @@ impl FloatTensorOps<Flex> for Flex {
         let min32 = min.to_f32().unwrap();
         let min64 = min.to_f64().unwrap();
         // `max` returns the non-NaN operand, which would map NaN to the bound.
-        // Test `is_nan` first so NaN propagates, as PyTorch does.
+        // Testing `is_nan` first lets NaN propagate, as PyTorch does.
         unary::unary_op(
             tensor,
             move |x: f32| if x.is_nan() || x > min32 { x } else { min32 },
@@ -630,7 +630,7 @@ impl FloatTensorOps<Flex> for Flex {
         let max32 = max.to_f32().unwrap();
         let max64 = max.to_f64().unwrap();
         // `min` returns the non-NaN operand, which would map NaN to the bound.
-        // Test `is_nan` first so NaN propagates, as PyTorch does.
+        // Testing `is_nan` first lets NaN propagate, as PyTorch does.
         unary::unary_op(
             tensor,
             move |x: f32| if x.is_nan() || x < max32 { x } else { max32 },
@@ -1330,66 +1330,5 @@ mod tests {
         let device = crate::FlexDevice;
         let t = Flex::float_random(shape, dist, &device, FloatDType::F16);
         assert_eq!(t.dtype(), DType::F16);
-    }
-
-    // Regression tests for #5609. `f32::max` / `f32::min` return the non-NaN
-    // operand, so clamp_min / clamp_max used to replace NaN with the bound while
-    // `float_clamp` (built on `f32::clamp`) propagated it.
-    #[test]
-    fn test_float_clamp_min_propagates_nan() {
-        use burn_backend::Scalar;
-        use burn_backend::ops::FloatTensorOps;
-
-        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
-        let out: Vec<f32> = Flex::float_clamp_min(t, Scalar::from(0.0f32))
-            .into_data()
-            .try_into_vec()
-            .unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [0.0, 2.0]);
-
-        let t = crate::FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 2.0]));
-        let out: Vec<f64> = Flex::float_clamp_min(t, Scalar::from(0.0f64))
-            .into_data()
-            .try_into_vec()
-            .unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [0.0, 2.0]);
-    }
-
-    #[test]
-    fn test_float_clamp_max_propagates_nan() {
-        use burn_backend::Scalar;
-        use burn_backend::ops::FloatTensorOps;
-
-        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
-        let out: Vec<f32> = Flex::float_clamp_max(t, Scalar::from(1.0f32))
-            .into_data()
-            .try_into_vec()
-            .unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [-1.0, 1.0]);
-
-        let t = crate::FlexTensor::from_data(TensorData::from([f64::NAN, -1.0f64, 2.0]));
-        let out: Vec<f64> = Flex::float_clamp_max(t, Scalar::from(1.0f64))
-            .into_data()
-            .try_into_vec()
-            .unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [-1.0, 1.0]);
-    }
-
-    #[test]
-    fn test_float_clamp_propagates_nan() {
-        use burn_backend::Scalar;
-        use burn_backend::ops::FloatTensorOps;
-
-        let t = crate::FlexTensor::from_data(TensorData::from([f32::NAN, -1.0, 2.0]));
-        let out: Vec<f32> = Flex::float_clamp(t, Scalar::from(0.0f32), Scalar::from(1.0f32))
-            .into_data()
-            .try_into_vec()
-            .unwrap();
-        assert!(out[0].is_nan());
-        assert_eq!(out[1..], [0.0, 1.0]);
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed. *(all steps but `audit`, see Testing)*
- [ ] Made sure the book is up to date with changes in this PR. *(no doc changes needed)*

### Related Issues/PRs

Fixes #5609. Filed #5659 for the same gap on the cube backends.

### Changes

`f32::max` / `f32::min` return the non-NaN operand, so `relu`, `float_clamp_min` and
`float_clamp_max` mapped NaN to the bound. `float_clamp` uses `f32::clamp` and propagates it, so the
crate disagreed with itself and with PyTorch. Testing `is_nan` before the comparison makes all four
agree.

`relu_backward` had the same hole: it masked on `out > 0.0`, false for NaN, so a NaN output lost its
gradient, while the trait default masks with `float_lower_equal_elem(output, 0)` and keeps it. That
fix is its own commit (204cfec) and can be split out if you would rather keep this PR to the forward
ops.

Only NaN behaves differently. Every other value takes the same branch as before, so callers in
`burn-nn` and the examples are unchanged. `relu(-0.0)` now returns `+0.0` instead of whichever zero
`f32::max` happened to pick.

`!(x <= 0.0)` is equivalent and compiles to the same symbol, but `clippy::neg_cmp_op_on_partial_ord`
rejects it under `--deny warnings`, so the `is_nan()` spelling stays.

### Testing

Tests are in `burn-backend-tests`, per the rule above each flex test module. Gating follows what the
backends actually do:

| op | flex | ndarray | cuda | metal |
| --- | --- | --- | --- | --- |
| `relu`, `clamp_min`, `clamp_max` | pass | pass | pass | pass |
| `clamp` (two-sided) | pass | pass | fail | not run |

The first row is ungated; two-sided `clamp` is gated to the CPU backends, as are the f64 variants.
Reverting either source fix makes the matching tests fail.

`cargo audit` cannot reach the RustSec database from here, so the remaining steps were run
separately: fmt, clippy with `--deny warnings`, typos, doc build, doc tests (238 passed), no-std
build and test (2978 passed), and the backends and examples shards. Flex suites in release: 4103
passed, 0 failed.
